### PR TITLE
Feat: WebSocket + STOMP 기본 설정 구현 (#33)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.boot:spring-boot-starter-security")
     testImplementation("org.springframework.security:spring-security-test")
     compileOnly("org.projectlombok:lombok")

--- a/src/main/java/com/back/domain/websocket/config/WebSocketConfig.java
+++ b/src/main/java/com/back/domain/websocket/config/WebSocketConfig.java
@@ -1,0 +1,36 @@
+package com.back.domain.websocket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    /**
+     * 메시지 브로커 설정
+     * - /topic: 1:N 브로드캐스트 (방 채팅)
+     * - /queue: 1:1 메시지 (개인 DM)
+     * - /app: 클라이언트에서 서버로 메시지 전송 시 prefix
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic", "/queue");
+        config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
+    }
+
+    /**
+     * STOMP 엔드포인트 등록
+     * 클라이언트가 WebSocket 연결을 위해 사용할 엔드포인트
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*") // 모든 도메인 허용 (개발용)
+                .withSockJS(); // SockJS 사용
+    }
+}

--- a/src/main/java/com/back/domain/websocket/controller/WebSocketTestController.java
+++ b/src/main/java/com/back/domain/websocket/controller/WebSocketTestController.java
@@ -1,0 +1,65 @@
+package com.back.domain.websocket.controller;
+
+import com.back.global.common.dto.RsData;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/websocket")
+public class WebSocketTestController { // WebSocket 기능 테스트용 REST 컨트롤러
+
+    // WebSocket 서버 상태 확인
+    @GetMapping("/health")
+    public ResponseEntity<RsData<Map<String, Object>>> healthCheck() {
+        log.info("WebSocket 헬스체크 요청");
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("service", "WebSocket");
+        data.put("status", "running");
+        data.put("timestamp", LocalDateTime.now());
+        data.put("endpoints", Map.of(
+                "websocket", "/ws",
+                "chat", "/app/rooms/{roomId}/chat",
+                "join", "/app/rooms/{roomId}/join",
+                "leave", "/app/rooms/{roomId}/leave"
+        ));
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success("WebSocket 서비스가 정상 동작중입니다.", data));
+    }
+
+    // WebSocket 연결 정보 제공
+    @GetMapping("/info")
+    public ResponseEntity<RsData<Map<String, Object>>> getConnectionInfo() {
+        log.info("WebSocket 연결 정보 요청");
+
+        Map<String, Object> connectionInfo = new HashMap<>();
+        connectionInfo.put("websocketUrl", "/ws");
+        connectionInfo.put("sockjsSupport", true);
+        connectionInfo.put("stompVersion", "1.2");
+        connectionInfo.put("subscribeTopics", Map.of(
+                "roomChat", "/topic/rooms/{roomId}/chat",
+                "privateMessage", "/user/queue/messages",
+                "notifications", "/user/queue/notifications"
+        ));
+        connectionInfo.put("sendDestinations", Map.of(
+                "roomChat", "/app/rooms/{roomId}/chat",
+                "joinRoom", "/app/rooms/{roomId}/join",
+                "leaveRoom", "/app/rooms/{roomId}/leave"
+        ));
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success("WebSocket 연결 정보", connectionInfo));
+    }
+}

--- a/src/main/java/com/back/global/entity/BaseEntity.java
+++ b/src/main/java/com/back/global/entity/BaseEntity.java
@@ -16,7 +16,7 @@ public abstract class BaseEntity {
     private Long id;
 
     @CreatedDate
-    private LocalDateTime createAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
     private LocalDateTime updatedAt;


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 온라인 스터디 카페 플랫폼의 실시간 채팅 기능을 위한 WebSocket + STOMP 기본 인프라 구축
- WebSocket 서버 설정 및 연결 테스트 완료

<br/>

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- **WebSocket 설정 구현**
  - `WebSocketConfig` 클래스 생성 및 STOMP 메시지 브로커 설정
  - WebSocket 엔드포인트 `/ws` 등록 (SockJS fallback 지원)
  - CORS 설정 (`setAllowedOriginPatterns("*")` - 개발환경용)

- **메시지 브로커 구성**
  - `/topic`: 1:N 브로드캐스트 (방 채팅용)
  - `/queue`: 1:1 메시지 (개인 DM용)  
  - `/app`: 클라이언트→서버 메시지 전송 prefix
  - `/user`: 개인 메시지 전용 prefix

- **헬스체크 API 구현**
  - `WebSocketTestController` 생성
  - `GET /api/websocket/health`: 서버 상태 확인 엔드포인트
  - `GET /api/websocket/info`: WebSocket 연결 정보 제공 엔드포인트

- **패키지 구조 생성**
  - `com.back.domain.websocket.config`: WebSocket 설정
  - `com.back.domain.websocket.controller`: WebSocket 컨트롤러
<br/>

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #33 

<br/>

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- **테스트 확인된 사항**
  - 서버 정상 실행 확인
  - 헬스체크 API 정상 응답 확인 (`/api/websocket/health`, `/api/websocket/info`)
  - WebSocket 연결 엔드포인트 `/ws` 접근 가능

- **다음 단계 작업 예정**
  - 실제 채팅 메시지 송수신 기능 구현
  - 채팅 메시지 DB 저장 로직 추가
  - 개인 DM 기능 구현

- **개발환경 설정**
  - CORS는 현재 모든 Origin 허용 (`*`) - 프로덕션 환경에서는 제한 필요
  - SockJS fallback 지원으로 WebSocket 미지원 브라우저 호환성 확보
<br/>

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화