### PR TITLE
Chore: Redis 설정 추가 (#57)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,10 +66,7 @@ dependencies {
 
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
-    implementation("it.ozimov:embedded-redis:0.7.3") {
-        exclude(group = "org.slf4j", module = "slf4j-simple")
-    }
-
+    implementation("com.github.codemonstur:embedded-redis:1.4.3")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,13 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation("it.ozimov:embedded-redis:0.7.3") {
+        exclude(group = "org.slf4j", module = "slf4j-simple")
+    }
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/global/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/back/global/config/EmbeddedRedisConfig.java
@@ -1,0 +1,42 @@
+package com.back.global.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+import redis.embedded.RedisServerBuilder;
+
+import java.io.IOException;
+
+/**
+ * Embedded Redis 설정 클래스
+ * - 개발 및 테스트 환경에서만 활성화 (dev, test 프로파일)
+ * - 애플리케이션 시작 시 내장 Redis 서버 시작
+ * - 애플리케이션 종료 시 내장 Redis 서버 중지
+ */
+@Configuration
+@Profile({"dev", "test"})
+public class EmbeddedRedisConfig {
+
+    private RedisServer redisServer;
+
+    public EmbeddedRedisConfig() throws IOException {
+        this.redisServer = new RedisServerBuilder()
+                .port(6379)
+                .setting("maxheap 256M")
+                .build();
+    }
+
+    @PostConstruct
+    public void startRedis() {
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+}

--- a/src/main/java/com/back/global/config/RedisConfig.java
+++ b/src/main/java/com/back/global/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.back.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis 설정 클래스
+ */
+@Configuration
+public class RedisConfig {
+
+    /**
+     * RedisTemplate 설정
+     * - Key: String
+     * - Value: JSON (Jackson)
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        // Key: String
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+
+        // Value: JSON
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        template.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+
+        return template;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,6 +5,11 @@ spring:
     username: sa
     password:
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   config:
     import: optional:file:.env[.properties]
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,11 +5,6 @@ spring:
     username: sa
     password:
 
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
 jwt:
   secret: test-jwt-secret-key-12345678901234567890
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:1800}  # 30분 (초 단위)

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -5,6 +5,11 @@ spring:
     username: sa
     password:
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 jwt:
   secret: test-jwt-secret-key-12345678901234567890
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:1800}  # 30분 (초 단위)

--- a/src/test/java/com/back/RedisConnectionTest.java
+++ b/src/test/java/com/back/RedisConnectionTest.java
@@ -1,0 +1,31 @@
+package com.back;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class RedisConnectionTest {
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Test
+    void redisShouldStoreAndGetValue() {
+        // given
+        String key = "test:key";
+        String value = "hello";
+
+        // when
+        redisTemplate.opsForValue().set(key, value);
+        String result = redisTemplate.opsForValue().get(key);
+
+        // then
+        assertThat(result).isEqualTo(value);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 개발/테스트 환경에서 사용할 Embedded Redis 설정 추가
- 운영 환경에서는 외부 Redis 연결을 고려할 수 있도록 구조 분리
- StringRedisTemplate을 이용해 기본 key-value 저장/조회 가능

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- spring-boot-starter-data-redis 의존성 추가
- embedded-redis 의존성 추가 (개발/테스트 환경용)
- EmbeddedRedisConfig 작성 (@Profile("local","test") 적용)
- RedisConfig 작성 → 직렬화 전략 기본 설정 (String 기반)
- application.yml에 Redis 설정 항목 추가 (localhost:6379)

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #57

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
