### PR TITLE
Feat: 로그인 API 구현 (#64)

### DIFF
--- a/src/main/java/com/back/domain/user/controller/AuthController.java
+++ b/src/main/java/com/back/domain/user/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.back.domain.user.controller;
 
+import com.back.domain.user.dto.LoginRequest;
 import com.back.domain.user.dto.UserRegisterRequest;
 import com.back.domain.user.dto.UserResponse;
 import com.back.domain.user.service.UserService;
@@ -7,6 +8,7 @@ import com.back.global.common.dto.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -42,6 +44,26 @@ public class AuthController {
                 .body(RsData.success(
                         "회원가입이 성공적으로 완료되었습니다. 이메일 인증을 완료해주세요.",
                         response
+                ));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "username + password로 로그인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그인 성공"),
+            @ApiResponse(responseCode = "401", description = "잘못된 아이디/비밀번호"),
+            @ApiResponse(responseCode = "403", description = "이메일 미인증/정지 계정"),
+            @ApiResponse(responseCode = "410", description = "탈퇴한 계정")
+    })
+    public ResponseEntity<RsData<UserResponse>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
+        UserResponse loginResponse = userService.login(request, response);
+        return ResponseEntity
+                .ok(RsData.success(
+                        "로그인에 성공했습니다.",
+                        loginResponse
                 ));
     }
 }

--- a/src/main/java/com/back/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/back/domain/user/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.back.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 사용자 로그인 요청을 나타내는 DTO
+ *
+ * @param username 사용자의 로그인 id
+ * @param password 사용자의 비밀번호
+ */
+public record LoginRequest(
+        @NotBlank String username,
+        @NotBlank String password
+) {}

--- a/src/main/java/com/back/domain/user/entity/User.java
+++ b/src/main/java/com/back/domain/user/entity/User.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 import java.util.ArrayList;
@@ -38,6 +39,8 @@ public class User extends BaseEntity {
 
     private String providerId;
 
+    // 사용자 상태 변경
+    @Setter
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus;
 

--- a/src/main/java/com/back/domain/user/service/UserService.java
+++ b/src/main/java/com/back/domain/user/service/UserService.java
@@ -106,6 +106,7 @@ public class UserService {
         String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getUsername(), user.getRole().name());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
+        // TODO: Refresh Token 저장소에 저장 로직 추가 예정 (현재는 stateless 방식)
         // Refresh Token을 HttpOnly 쿠키로 설정
         Cookie cookie = new Cookie("refreshToken", refreshToken);
         cookie.setHttpOnly(true);

--- a/src/main/java/com/back/domain/user/service/UserService.java
+++ b/src/main/java/com/back/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.back.domain.user.dto.UserRegisterRequest;
 import com.back.domain.user.dto.UserResponse;
 import com.back.domain.user.entity.User;
 import com.back.domain.user.entity.UserProfile;
+import com.back.domain.user.entity.UserStatus;
 import com.back.domain.user.repository.UserProfileRepository;
 import com.back.domain.user.repository.UserRepository;
 import com.back.global.exception.CustomException;
@@ -62,8 +63,13 @@ public class UserService {
         // 연관관계 설정
         user.setUserProfile(profile);
 
+        // TODO: 임시 로직 - 이메일 인증 기능 개발 전까지는 바로 ACTIVE 처리
+        user.setUserStatus(UserStatus.ACTIVE);
+
         // 저장 (cascade로 Profile도 함께 저장됨)
         User saved = userRepository.save(user);
+
+        // TODO: 이메일 인증 로직 추가 예정
 
         // UserResponse 변환 및 반환
         return UserResponse.from(saved, profile);

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -14,6 +14,10 @@ public enum ErrorCode {
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "USER_003", "이미 사용 중인 이메일입니다."),
     NICKNAME_DUPLICATED(HttpStatus.CONFLICT, "USER_004", "이미 사용 중인 닉네임입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER_005", "비밀번호는 최소 8자 이상, 숫자/특수문자를 포함해야 합니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "USER_006", "아이디 또는 비밀번호가 올바르지 않습니다."),
+    USER_EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "USER_007", "이메일 인증 후 로그인할 수 있습니다."),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, "USER_008", "정지된 계정입니다. 관리자에게 문의하세요."),
+    USER_DELETED(HttpStatus.GONE, "USER_009", "탈퇴한 계정입니다."),
 
     // ======================== 스터디룸 관련 ========================
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM_001", "존재하지 않는 방입니다."),

--- a/src/main/java/com/back/global/initData/DevInitData.java
+++ b/src/main/java/com/back/global/initData/DevInitData.java
@@ -1,0 +1,59 @@
+package com.back.global.initData;
+
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserProfile;
+import com.back.domain.user.entity.UserStatus;
+import com.back.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+@Configuration
+@Profile("dev")
+@RequiredArgsConstructor
+public class DevInitData {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Bean
+    ApplicationRunner DevInitDataApplicationRunner() {
+        return args -> {
+            initUsers();
+        };
+    }
+
+    @Transactional
+    public void initUsers() {
+        if (userRepository.count() == 0) {
+            User admin = User.createAdmin(
+                    "admin",
+                    "admin@example.com",
+                    passwordEncoder.encode("12345678!")
+            );
+            admin.setUserProfile(new UserProfile(admin, "관리자", null, null, null, 0));
+            userRepository.save(admin);
+
+            User user1 = User.createUser(
+                    "user1",
+                    "user1@example.com",
+                    passwordEncoder.encode("12345678!")
+            );
+            user1.setUserProfile(new UserProfile(user1, "사용자1", null, null, null, 0));
+            user1.setUserStatus(UserStatus.ACTIVE);
+            userRepository.save(user1);
+
+            User user2 = User.createUser(
+                    "user2",
+                    "user2@example.com",
+                    passwordEncoder.encode("12345678!")
+            );
+            user2.setUserProfile(new UserProfile(user2, "사용자2", null, null, null, 0));
+            user2.setUserStatus(UserStatus.ACTIVE);
+            userRepository.save(user2);
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 로그인 API 구현 및 테스트 작성
- 개발 환경에서 실행 시 기본 계정을 자동 생성하는 초기 데이터 추가

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 1. 로그인 API 구현

* `AuthController`에 `POST /api/auth/login` 추가
  * username + password로 로그인
  * 성공 시:
    * `Authorization: Bearer {accessToken}` 헤더 발급
    * `Set-Cookie: refreshToken=...; HttpOnly` 쿠키 발급
    * Body에 `RsData<UserResponse>` 반환

* `UserService#login` 로직 구현
  * 사용자 조회 → 비밀번호 검증 → 상태 검증(PENDING, SUSPENDED, DELETED)
  * JWT Access/Refresh Token 발급 (`JwtTokenProvider`)
  * Refresh Token을 HttpOnly 쿠키로 저장
  * Access Token을 응답 헤더에 설정
  * UserResponse 반환

### 2. 예외 처리

* 상태별 예외 정의 (`ErrorCode`)
  * 잘못된 아이디/비밀번호 → 401
  * 이메일 미인증/정지 계정 → 403
  * 탈퇴 계정 → 410

### 3. 테스트 코드 추가

* Service Test (`UserServiceTest`)
* Controller Test (`AuthControllerTest`)
* 기존 회원가입 테스트와 함께 통합 검증

### 4. 초기 데이터 마련

* `DevInitData` 추가
  * 애플리케이션 실행 시 개발 환경(dev)에서 기본 계정 자동 생성
  * `user1 / 12345678!` (USER)
  * `user2 / 12345678!` (USER)
  * `admin / 12345678!` (ADMIN)

* 실행 시 DB가 비어있을 때만 데이터 삽입

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #64

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 회원가입 시 사용자 상태를 임시로 ACTIVE로 설정 -> 추후 이메일 인증 API 구현 후 수정 예정
  - 예정 흐름: 회원가입 직후 status=PENDING -> 이메일 인증 후 status=ACTIVE
- 로그아웃 API, 인증 토큰(access) 재발급 API, 이메일 인증 API 순으로 구현 예정

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
