### PR TITLE
Feat: 로그아웃 API 구현 (#68)

### DIFF
--- a/src/main/java/com/back/domain/user/controller/AuthController.java
+++ b/src/main/java/com/back/domain/user/controller/AuthController.java
@@ -22,20 +22,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
     private final UserService userService;
 
+    // 회원가입
     @PostMapping("/register")
-    @Operation(
-            summary = "회원가입",
-            description = "신규 사용자를 등록합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "201", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 / 비밀번호 정책 위반"),
-            @ApiResponse(responseCode = "409", description = "중복된 아이디/이메일/닉네임"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-    })
     public ResponseEntity<RsData<UserResponse>> register(
             @Valid @RequestBody UserRegisterRequest request
     ) {
@@ -48,14 +39,8 @@ public class AuthController {
                 ));
     }
 
+    // 로그인
     @PostMapping("/login")
-    @Operation(summary = "로그인", description = "username + password로 로그인합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "401", description = "잘못된 아이디/비밀번호"),
-            @ApiResponse(responseCode = "403", description = "이메일 미인증/정지 계정"),
-            @ApiResponse(responseCode = "410", description = "탈퇴한 계정")
-    })
     public ResponseEntity<RsData<UserResponse>> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletResponse response
@@ -68,14 +53,8 @@ public class AuthController {
                 ));
     }
 
+    // 로그아웃
     @PostMapping("/logout")
-    @Operation(summary = "로그아웃", description = "Refresh Token을 무효화합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "401", description = "이미 만료되었거나 유효하지 않은 토큰"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
-    })
     public ResponseEntity<RsData<Void>> logout(
             HttpServletRequest request,
             HttpServletResponse response

--- a/src/main/java/com/back/domain/user/controller/AuthController.java
+++ b/src/main/java/com/back/domain/user/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.back.global.common.dto.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -64,6 +65,26 @@ public class AuthController {
                 .ok(RsData.success(
                         "로그인에 성공했습니다.",
                         loginResponse
+                ));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "Refresh Token을 무효화합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "이미 만료되었거나 유효하지 않은 토큰"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    public ResponseEntity<RsData<Void>> logout(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        userService.logout(request, response);
+        return ResponseEntity
+                .ok(RsData.success(
+                        "로그아웃 되었습니다.",
+                        null
                 ));
     }
 }

--- a/src/main/java/com/back/domain/user/entity/UserToken.java
+++ b/src/main/java/com/back/domain/user/entity/UserToken.java
@@ -2,6 +2,7 @@ package com.back.domain.user.entity;
 
 import com.back.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class UserToken extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/back/domain/user/repository/UserTokenRepository.java
+++ b/src/main/java/com/back/domain/user/repository/UserTokenRepository.java
@@ -1,0 +1,13 @@
+package com.back.domain.user.repository;
+
+import com.back.domain.user.entity.UserToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserTokenRepository extends JpaRepository<UserToken, Long> {
+    Optional<UserToken> findByRefreshToken(String refreshToken);
+    void deleteByRefreshToken(String refreshToken);
+}

--- a/src/main/java/com/back/domain/user/service/UserService.java
+++ b/src/main/java/com/back/domain/user/service/UserService.java
@@ -144,8 +144,13 @@ public class UserService {
         // 쿠키에서 Refresh Token 추출
         String refreshToken = resolveRefreshToken(request);
 
-        // 토큰 검증
-        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) {
+        // Refresh Token 존재 여부 확인
+        if (refreshToken == null) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+
+        // Refresh Token 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new CustomException(ErrorCode.INVALID_TOKEN);
         }
 

--- a/src/main/java/com/back/domain/user/service/UserService.java
+++ b/src/main/java/com/back/domain/user/service/UserService.java
@@ -84,13 +84,11 @@ public class UserService {
 
     /**
      * 로그인 서비스
-     * 1. 사용자 조회 (username)
-     * 2. 비밀번호 검증
-     * 3. 사용자 상태 체크 (PENDING, SUSPENDED, DELETED)
-     * 4. Access Token, Refresh Token 생성
-     * 5. Refresh Token을 HttpOnly 쿠키로 설정
-     * 6. Access Token을 응답 헤더에 설정
-     * 7. UserResponse 반환
+     * 1. 사용자 조회 및 비밀번호 검증
+     * 2. 사용자 상태 검증 (PENDING, SUSPENDED, DELETED)
+     * 3. Access/Refresh Token 발급
+     * 4. Refresh Token을 HttpOnly 쿠키로, Access Token은 헤더로 설정
+     * 5. UserResponse 반환
      */
     public UserResponse login(LoginRequest request, HttpServletResponse response) {
         // 사용자 조회
@@ -137,6 +135,11 @@ public class UserService {
         return UserResponse.from(user, user.getUserProfile());
     }
 
+    /**
+     * 로그아웃 서비스
+     * 1. Refresh Token 검증 및 DB 삭제
+     * 2. 쿠키 삭제
+     */
     public void logout(HttpServletRequest request, HttpServletResponse response) {
         // 쿠키에서 Refresh Token 추출
         String refreshToken = resolveRefreshToken(request);

--- a/src/main/java/com/back/global/security/JwtTokenProvider.java
+++ b/src/main/java/com/back/global/security/JwtTokenProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -33,6 +34,7 @@ public class JwtTokenProvider {
     @Value("${jwt.access-token-expiration}")
     private long accessTokenExpirationInSeconds;
 
+    @Getter
     @Value("${jwt.refresh-token-expiration}")
     private long refreshTokenExpirationInSeconds;
 

--- a/src/main/java/com/back/global/util/CookieUtil.java
+++ b/src/main/java/com/back/global/util/CookieUtil.java
@@ -1,0 +1,25 @@
+package com.back.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CookieUtil {
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge, String path) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath(path);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void clearCookie(HttpServletResponse response, String name, String path) {
+        Cookie cookie = new Cookie(name, null);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath(path);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+    }
+}


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 로그아웃 API 구현 및 테스트 작성
- Refresh Token을 DB(`UserToken`)에 저장하도록 개선
- Swagger 명세를 인터페이스(`AuthControllerDocs`)로 분리하여 컨트롤러와 문서를 분리

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 1. 인증/인가

  
* `UserToken` 엔티티 및 `UserTokenRepository`
  * Refresh Token DB 저장/삭제 관리

* `UserService`
  * 로그인 시: AccessToken 발급 + RefreshToken 저장/쿠키 설정
  * 로그아웃 시: RefreshToken 유효성 검증 + DB 삭제 + 쿠키 만료 처리
  
* `CookieUtil`
  * 쿠키 생성/삭제 유틸 추가 (중복 코드 제거)

### 2. 컨트롤러

* `AuthController`
  * `/logout` API 구현
  * Swagger 문서 어노테이션 제거 → `AuthControllerDocs` 인터페이스에서 관리

* `AuthControllerDocs`
  * Swagger 명세 및 Example JSON 정리

### 3. 테스트

* `UserServiceTest`
* `AuthControllerTest`

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #68

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- Swagger 명세는 AuthControllerDocs 인터페이스로 분리하여 관리하도록 했습니다.
- 향후 Access Token 재발급 API(/api/auth/refresh) 구현 예정입니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
