### PR TITLE
Feat: 회원 탈퇴 API 구현 (#101)

### DIFF
--- a/src/main/java/com/back/domain/user/controller/UserController.java
+++ b/src/main/java/com/back/domain/user/controller/UserController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController implements UserControllerDocs {
     private final UserService userService;
 
+    // 내 정보 조회
     @GetMapping("/me")
     public ResponseEntity<RsData<UserDetailResponse>> getMyInfo (
             @AuthenticationPrincipal CustomUserDetails user
@@ -29,6 +30,7 @@ public class UserController implements UserControllerDocs {
                 ));
     }
 
+    // 내 정보 수정
     @PatchMapping("/me")
     public ResponseEntity<RsData<UserDetailResponse>> updateMyProfile(
             @AuthenticationPrincipal CustomUserDetails user,
@@ -43,6 +45,7 @@ public class UserController implements UserControllerDocs {
         );
     }
 
+    // 내 계정 삭제
     @DeleteMapping("/me")
     public ResponseEntity<RsData<Void>> deleteMyAccount(
             @AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/com/back/domain/user/controller/UserController.java
+++ b/src/main/java/com/back/domain/user/controller/UserController.java
@@ -42,4 +42,15 @@ public class UserController implements UserControllerDocs {
                 )
         );
     }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<RsData<Void>> deleteMyAccount(
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        userService.deleteUser(user.getUserId());
+        return ResponseEntity
+                .ok(RsData.success(
+                        "회원 탈퇴가 완료되었습니다."
+                ));
+    }
 }

--- a/src/main/java/com/back/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/back/domain/user/controller/UserControllerDocs.java
@@ -87,7 +87,7 @@ public interface UserControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "401",
-                    description = "인증 실패 (Access Token 문제)",
+                    description = "인증 실패 (토큰 없음/잘못됨/만료)",
                     content = @Content(
                             mediaType = "application/json",
                             examples = {
@@ -99,7 +99,7 @@ public interface UserControllerDocs {
                                               "data": null
                                             }
                                             """),
-                                    @ExampleObject(name = "유효하지 않은 토큰", value = """
+                                    @ExampleObject(name = "잘못된 토큰", value = """
                                             {
                                               "success": false,
                                               "code": "AUTH_002",
@@ -302,5 +302,124 @@ public interface UserControllerDocs {
     ResponseEntity<RsData<UserDetailResponse>> updateMyProfile(
             @AuthenticationPrincipal CustomUserDetails user,
             @Valid @RequestBody UpdateUserProfileRequest request
+    );
+
+    @Operation(
+            summary = "내 계정 삭제",
+            description = "로그인한 사용자의 계정을 탈퇴 처리합니다. " +
+                    "탈퇴 시 사용자 상태는 DELETED로 변경되며, 프로필 정보는 마스킹 처리됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "회원 탈퇴가 완료되었습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "정지된 계정",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "USER_008",
+                                      "message": "정지된 계정입니다. 관리자에게 문의하세요.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "410",
+                    description = "탈퇴한 계정",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "USER_009",
+                                      "message": "탈퇴한 계정입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 없음/잘못됨/만료)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "토큰 없음", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_001",
+                                              "message": "인증이 필요합니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "잘못된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_002",
+                                              "message": "유효하지 않은 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "만료된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_004",
+                                              "message": "만료된 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "USER_001",
+                                      "message": "존재하지 않는 사용자입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<Void>> deleteMyAccount(
+            @AuthenticationPrincipal CustomUserDetails user
     );
 }

--- a/src/main/java/com/back/domain/user/service/UserService.java
+++ b/src/main/java/com/back/domain/user/service/UserService.java
@@ -27,17 +27,8 @@ public class UserService {
      */
     public UserDetailResponse getUserInfo(Long userId) {
 
-        // userId로 User 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        // UserStatus가 DELETED, SUSPENDED면 예외 처리
-        if (user.getUserStatus() == UserStatus.DELETED) {
-            throw new CustomException(ErrorCode.USER_DELETED);
-        }
-        if (user.getUserStatus() == UserStatus.SUSPENDED) {
-            throw new CustomException(ErrorCode.USER_SUSPENDED);
-        }
+        // 사용자 조회 및 상태 검증
+        User user = getValidUser(userId);
 
         // UserDetailResponse로 변환하여 반환
         return UserDetailResponse.from(user);
@@ -52,17 +43,8 @@ public class UserService {
      */
     public UserDetailResponse updateUserProfile(Long userId, UpdateUserProfileRequest request) {
 
-        // userId로 User 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        // UserStatus가 DELETED, SUSPENDED면 예외 처리
-        if (user.getUserStatus() == UserStatus.DELETED) {
-            throw new CustomException(ErrorCode.USER_DELETED);
-        }
-        if (user.getUserStatus() == UserStatus.SUSPENDED) {
-            throw new CustomException(ErrorCode.USER_SUSPENDED);
-        }
+        // 사용자 조회 및 상태 검증
+        User user = getValidUser(userId);
 
         // 닉네임 중복 검사 (본인 제외)
         if (userProfileRepository.existsByNicknameAndUserIdNot(request.nickname(), userId)) {
@@ -78,5 +60,57 @@ public class UserService {
 
         // UserDetailResponse로 변환하여 반환
         return UserDetailResponse.from(user);
+    }
+
+    /**
+     * 사용자 탈퇴 서비스 (soft delete)
+     * 1. 사용자 조회 및 상태 검증
+     * 2. UserStatus를 DELETED로 변경
+     */
+    public void deleteUser(Long userId) {
+
+        // 사용자 조회 및 상태 검증
+        User user = getValidUser(userId);
+
+        // 상태 변경 (soft delete)
+        user.setUserStatus(UserStatus.DELETED);
+
+        // 식별 정보 변경 (username, email, provider, providerId)
+        user.setUsername("deleted_" + user.getUsername());
+        user.setEmail("deleted_" + user.getEmail());
+        user.setProvider("deleted_" + user.getProvider());
+        user.setProviderId("deleted_" + user.getProviderId());
+
+        // 개인정보 마스킹
+        UserProfile profile = user.getUserProfile();
+        if (profile != null) {
+            profile.setNickname("탈퇴한 회원");
+            profile.setProfileImageUrl(null);
+            profile.setBio(null);
+            profile.setBirthDate(null);
+        }
+    }
+
+    /**
+     * 유효한 사용자 조회 및 상태 검증
+     *
+     * @param userId 사용자 ID
+     * @return user  조회된 사용자 엔티티
+     */
+    private User getValidUser(Long userId) {
+
+        // userId로 User 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // UserStatus가 DELETED, SUSPENDED면 예외 처리
+        if (user.getUserStatus() == UserStatus.DELETED) {
+            throw new CustomException(ErrorCode.USER_DELETED);
+        }
+        if (user.getUserStatus() == UserStatus.SUSPENDED) {
+            throw new CustomException(ErrorCode.USER_SUSPENDED);
+        }
+
+        return user;
     }
 }

--- a/src/main/java/com/back/global/security/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/back/global/security/oauth/CustomOAuth2UserService.java
@@ -2,7 +2,6 @@ package com.back.global.security.oauth;
 
 import com.back.domain.user.entity.User;
 import com.back.domain.user.entity.UserProfile;
-import com.back.domain.user.repository.UserProfileRepository;
 import com.back.domain.user.repository.UserRepository;
 import com.back.global.exception.CustomException;
 import com.back.global.exception.ErrorCode;

--- a/src/test/java/com/back/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/back/domain/user/controller/UserControllerTest.java
@@ -21,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -325,6 +327,121 @@ class UserControllerTest {
                         .header("Authorization", "Bearer " + expiredToken)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_004"))
+                .andExpect(jsonPath("$.message").value("만료된 액세스 토큰입니다."));
+    }
+
+    // ====================== 내 계정 삭제 테스트 ======================
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 → 200 OK")
+    void deleteMyAccount_success() throws Exception {
+        // given: 정상 유저 저장
+        User user = User.createUser("deleteuser", "delete@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "홍길동", "https://cdn.example.com/1.png", "소개글", LocalDate.of(1990, 1, 1), 100));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        String accessToken = generateAccessToken(user);
+
+        // when & then
+        mvc.perform(delete("/api/users/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("SUCCESS_200"))
+                .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
+
+        // DB 반영 확인
+        User deleted = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(deleted.getUserStatus()).isEqualTo(UserStatus.DELETED);
+        assertThat(deleted.getUsername()).startsWith("deleted_");
+        assertThat(deleted.getEmail()).startsWith("deleted_");
+        assertThat(deleted.getProvider()).startsWith("deleted_");
+        assertThat(deleted.getProviderId()).startsWith("deleted_");
+        assertThat(deleted.getUserProfile().getNickname()).isEqualTo("탈퇴한 회원");
+    }
+
+    @Test
+    @DisplayName("이미 탈퇴한 계정 탈퇴 시도 → 410 Gone")
+    void deleteMyAccount_alreadyDeleted() throws Exception {
+        // given: DELETED 상태 유저 저장
+        User user = User.createUser("alreadydeleted", "already@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "닉네임", null, null, null, 0));
+        user.setUserStatus(UserStatus.DELETED);
+        userRepository.save(user);
+
+        String accessToken = generateAccessToken(user);
+
+        // when & then
+        mvc.perform(delete("/api/users/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.code").value("USER_009"))
+                .andExpect(jsonPath("$.message").value("탈퇴한 계정입니다."));
+    }
+
+    @Test
+    @DisplayName("정지된 계정 탈퇴 시도 → 403 Forbidden")
+    void deleteMyAccount_suspendedUser() throws Exception {
+        // given: SUSPENDED 상태 유저 저장
+        User user = User.createUser("suspendeddelete", "suspendeddelete@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "닉네임", null, null, null, 0));
+        user.setUserStatus(UserStatus.SUSPENDED);
+        userRepository.save(user);
+
+        String accessToken = generateAccessToken(user);
+
+        // when & then
+        mvc.perform(delete("/api/users/me")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value("USER_008"))
+                .andExpect(jsonPath("$.message").value("정지된 계정입니다. 관리자에게 문의하세요."));
+    }
+
+    @Test
+    @DisplayName("AccessToken 없음으로 회원 탈퇴 시도 → 401 Unauthorized")
+    void deleteMyAccount_noAccessToken() throws Exception {
+        mvc.perform(delete("/api/users/me"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_001"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+    @Test
+    @DisplayName("잘못된 AccessToken으로 회원 탈퇴 시도 → 401 Unauthorized (AUTH_002)")
+    void deleteMyAccount_invalidAccessToken() throws Exception {
+        mvc.perform(delete("/api/users/me")
+                        .header("Authorization", "Bearer invalidToken"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_002"))
+                .andExpect(jsonPath("$.message").value("유효하지 않은 액세스 토큰입니다."));
+    }
+
+    @Test
+    @DisplayName("만료된 AccessToken으로 회원 탈퇴 시도 → 401 Unauthorized (AUTH_004)")
+    void deleteMyAccount_expiredAccessToken() throws Exception {
+        // given
+        User user = User.createUser("expiredDelete", "expireddelete@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "닉네임", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        String expiredToken = testJwtTokenProvider.createExpiredAccessToken(
+                user.getId(), user.getUsername(), user.getRole().name()
+        );
+
+        // when & then
+        mvc.perform(delete("/api/users/me")
+                        .header("Authorization", "Bearer " + expiredToken))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AUTH_004"))


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 로그인한 사용자가 자신의 계정을 탈퇴할 수 있는 API 구현 및 테스트 작성

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

* `UserController`
  * `DELETE /api/users/me` 엔드포인트 추가
  * 로그인한 본인 계정만 탈퇴 가능

* `UserService`
  * `deleteUser(Long userId)` 메서드 구현
  * `User` 상태를 `DELETED`로 변경
  * `username`, `email`, `provider`, `providerId` 마스킹 처리
  * `UserProfile` 닉네임, 이미지, bio, birthDate 마스킹 처리

* `ErrorCode`
  * `USER_ALREADY_DELETED`(410 Gone) 예외 코드 추가

* Swagger 문서(`UserControllerDocs`)에 회원 탈퇴 API 문서화

* 테스트 코드 작성
  * `UserServiceTest` → 회원 탈퇴 성공/예외 시나리오 단위 테스트 추가
  * `UserControllerTest` → 회원 탈퇴 API E2E 테스트 추가 (200, 401, 403, 410 등)
  
## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #101

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 회원 탈퇴 시 실제 DB 삭제가 아닌 Soft Delete 방식 적용
- 개인정보는 마스킹 처리하여 추후 재가입 시 중복되지 않도록 함
- 추후 정책에 따라 재가입 허용/불가 여부 조정 가능

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
