### PR TITLE
Feat: 비밀번호 변경 API 구현 (#102)

### DIFF
--- a/src/main/java/com/back/domain/user/controller/UserController.java
+++ b/src/main/java/com/back/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.back.domain.user.controller;
 
+import com.back.domain.user.dto.ChangePasswordRequest;
 import com.back.domain.user.dto.UpdateUserProfileRequest;
 import com.back.domain.user.dto.UserDetailResponse;
 import com.back.domain.user.service.UserService;
@@ -41,8 +42,20 @@ public class UserController implements UserControllerDocs {
                 .ok(RsData.success(
                         "회원 정보를 수정했습니다.",
                         updated
-                )
-        );
+                ));
+    }
+
+    // 내 비밀번호 변경
+    @PatchMapping("/me/password")
+    public ResponseEntity<RsData<Void>> changeMyPassword(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Valid @RequestBody ChangePasswordRequest request
+    ) {
+        userService.changePassword(user.getUserId(), request);
+        return ResponseEntity
+                .ok(RsData.success(
+                        "비밀번호가 변경되었습니다."
+                ));
     }
 
     // 내 계정 삭제

--- a/src/main/java/com/back/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/back/domain/user/controller/UserControllerDocs.java
@@ -1,5 +1,6 @@
 package com.back.domain.user.controller;
 
+import com.back.domain.user.dto.ChangePasswordRequest;
 import com.back.domain.user.dto.UpdateUserProfileRequest;
 import com.back.domain.user.dto.UserDetailResponse;
 import com.back.global.common.dto.RsData;
@@ -302,6 +303,149 @@ public interface UserControllerDocs {
     ResponseEntity<RsData<UserDetailResponse>> updateMyProfile(
             @AuthenticationPrincipal CustomUserDetails user,
             @Valid @RequestBody UpdateUserProfileRequest request
+    );
+
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "로그인한 사용자가 본인 계정의 비밀번호를 변경합니다. " +
+                    "현재 비밀번호를 검증하고, 새 비밀번호는 정책(최소 8자, 숫자/특수문자 포함)을 만족해야 합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 변경 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "success": true,
+                                  "code": "SUCCESS_200",
+                                  "message": "비밀번호가 변경되었습니다.",
+                                  "data": null
+                                }
+                                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "새 비밀번호 정책 위반",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "success": false,
+                                  "code": "USER_005",
+                                  "message": "비밀번호는 최소 8자 이상, 숫자/특수문자를 포함해야 합니다.",
+                                  "data": null
+                                }
+                                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "정지된 계정",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "success": false,
+                                  "code": "USER_008",
+                                  "message": "정지된 계정입니다. 관리자에게 문의하세요.",
+                                  "data": null
+                                }
+                                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "410",
+                    description = "탈퇴한 계정",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "success": false,
+                                  "code": "USER_009",
+                                  "message": "탈퇴한 계정입니다.",
+                                  "data": null
+                                }
+                                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 없음/잘못됨/만료 또는 현재 비밀번호 불일치)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "토큰 없음", value = """
+                                        {
+                                          "success": false,
+                                          "code": "AUTH_001",
+                                          "message": "인증이 필요합니다.",
+                                          "data": null
+                                        }
+                                        """),
+                                    @ExampleObject(name = "잘못된 토큰", value = """
+                                        {
+                                          "success": false,
+                                          "code": "AUTH_002",
+                                          "message": "유효하지 않은 액세스 토큰입니다.",
+                                          "data": null
+                                        }
+                                        """),
+                                    @ExampleObject(name = "만료된 토큰", value = """
+                                        {
+                                          "success": false,
+                                          "code": "AUTH_004",
+                                          "message": "만료된 액세스 토큰입니다.",
+                                          "data": null
+                                        }
+                                        """),
+                                    @ExampleObject(name = "현재 비밀번호 불일치", value = """
+                                        {
+                                          "success": false,
+                                          "code": "USER_006",
+                                          "message": "아이디 또는 비밀번호가 올바르지 않습니다.",
+                                          "data": null
+                                        }
+                                        """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "success": false,
+                                  "code": "USER_001",
+                                  "message": "존재하지 않는 사용자입니다.",
+                                  "data": null
+                                }
+                                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                {
+                                  "success": false,
+                                  "code": "COMMON_500",
+                                  "message": "서버 오류가 발생했습니다.",
+                                  "data": null
+                                }
+                                """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<Void>> changeMyPassword(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @Valid @RequestBody ChangePasswordRequest request
     );
 
     @Operation(

--- a/src/main/java/com/back/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/back/domain/user/controller/UserControllerDocs.java
@@ -343,6 +343,21 @@ public interface UserControllerDocs {
             ),
             @ApiResponse(
                     responseCode = "403",
+                    description = "소셜 로그인 회원 비밀번호 변경 불가",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                {
+                  "success": false,
+                  "code": "USER_010",
+                  "message": "소셜 로그인 회원은 비밀번호를 변경할 수 없습니다.",
+                  "data": null
+                }
+                """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
                     description = "정지된 계정",
                     content = @Content(
                             mediaType = "application/json",

--- a/src/main/java/com/back/domain/user/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/back/domain/user/dto/ChangePasswordRequest.java
@@ -1,0 +1,15 @@
+package com.back.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 비밀번호 변경 요청을 나타내는 DTO
+ *
+ * @param currentPassword 현재 비밀번호
+ * @param newPassword 새로운 비밀번호
+ */
+public record ChangePasswordRequest(
+        @NotBlank String currentPassword,
+        @NotBlank String newPassword
+) {
+}

--- a/src/main/java/com/back/domain/user/service/AuthService.java
+++ b/src/main/java/com/back/domain/user/service/AuthService.java
@@ -15,6 +15,7 @@ import com.back.global.exception.CustomException;
 import com.back.global.exception.ErrorCode;
 import com.back.global.security.jwt.JwtTokenProvider;
 import com.back.global.util.CookieUtil;
+import com.back.global.util.PasswordValidator;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -48,7 +49,7 @@ public class AuthService {
         validateDuplicate(request);
 
         // 비밀번호 정책 검증
-        validatePasswordPolicy(request.password());
+        PasswordValidator.validate(request.password());
 
         // User 엔티티 생성 (기본 Role.USER, Status.PENDING)
         User user = User.createUser(
@@ -213,18 +214,6 @@ public class AuthService {
         }
         if (userProfileRepository.existsByNickname(request.nickname())) {
             throw new CustomException(ErrorCode.NICKNAME_DUPLICATED);
-        }
-    }
-
-    /**
-     * 비밀번호 정책 검증
-     * - 최소 8자 이상
-     * - 숫자 및 특수문자 반드시 포함
-     */
-    private void validatePasswordPolicy(String password) {
-        String regex = "^(?=.*[0-9])(?=.*[!@#$%^&*]).{8,}$";
-        if (!password.matches(regex)) {
-            throw new CustomException(ErrorCode.INVALID_PASSWORD);
         }
     }
 

--- a/src/main/java/com/back/domain/user/service/UserService.java
+++ b/src/main/java/com/back/domain/user/service/UserService.java
@@ -78,6 +78,11 @@ public class UserService {
         // 사용자 조회 및 상태 검증
         User user = getValidUser(userId);
 
+        // 소셜 로그인 사용자는 비밀번호 변경 불가
+        if (user.getProvider() != null) {
+            throw new CustomException(ErrorCode.SOCIAL_PASSWORD_CHANGE_FORBIDDEN);
+        }
+
         // 현재 비밀번호 검증
         if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
             throw new CustomException(ErrorCode.INVALID_CREDENTIALS);

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     USER_EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "USER_007", "이메일 인증 후 로그인할 수 있습니다."),
     USER_SUSPENDED(HttpStatus.FORBIDDEN, "USER_008", "정지된 계정입니다. 관리자에게 문의하세요."),
     USER_DELETED(HttpStatus.GONE, "USER_009", "탈퇴한 계정입니다."),
+    SOCIAL_PASSWORD_CHANGE_FORBIDDEN(HttpStatus.FORBIDDEN, "USER_010", "소셜 로그인 회원은 비밀번호를 변경할 수 없습니다."),
 
     // ======================== 스터디룸 관련 ========================
     ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "ROOM_001", "존재하지 않는 방입니다."),

--- a/src/main/java/com/back/global/util/PasswordValidator.java
+++ b/src/main/java/com/back/global/util/PasswordValidator.java
@@ -1,0 +1,28 @@
+package com.back.global.util;
+
+import com.back.global.exception.CustomException;
+import com.back.global.exception.ErrorCode;
+
+/**
+ * 비밀번호 유효성 검증 유틸리티 클래스
+ *
+ * 비밀번호 정책:
+ * - 최소 8자 이상
+ * - 최소 하나의 숫자 포함
+ * - 최소 하나의 특수문자 포함 (!@#$%^&*)
+ */
+public class PasswordValidator {
+    private static final String PASSWORD_REGEX = "^(?=.*[0-9])(?=.*[!@#$%^&*]).{8,}$";
+
+    /**
+     * 비밀번호 유효성 검증 메서드
+     *
+     * @param password 검증할 비밀번호
+     * @throws CustomException 비밀번호가 정책에 맞지 않을 경우 USER_005 예외 발생
+     */
+    public static void validate(String password) {
+        if (!password.matches(PASSWORD_REGEX)) {
+            throw new CustomException(ErrorCode.INVALID_PASSWORD);
+        }
+    }
+}

--- a/src/test/java/com/back/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/back/domain/user/service/UserServiceTest.java
@@ -237,6 +237,23 @@ class UserServiceTest {
     }
 
     @Test
+    @DisplayName("소셜 로그인 회원 비밀번호 변경 시도 → SOCIAL_PASSWORD_CHANGE_FORBIDDEN 예외")
+    void changePassword_socialUser() {
+        // given
+        User user = User.createUser("socialuser", "social@example.com", null);
+        user.setProvider("kakao"); // 소셜 로그인 회원
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        ChangePasswordRequest request = new ChangePasswordRequest("dummy", "NewP@ssw0rd!");
+
+        // when & then
+        assertThatThrownBy(() -> userService.changePassword(user.getId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.SOCIAL_PASSWORD_CHANGE_FORBIDDEN.getMessage());
+    }
+
+    @Test
     @DisplayName("탈퇴한 유저 비밀번호 변경 → USER_DELETED 예외")
     void changePassword_deletedUser() {
         // given


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 로그인한 사용자가 본인 계정의 비밀번호를 변경할 수 있는 API 구현

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 1. 기능 구현

* **UserController**
  * `PATCH /api/users/me/password` 엔드포인트 추가

* **UserService**
  * `changePassword(Long userId, ChangePasswordRequest request)` 메서드 구현
  * 소셜 로그인 회원 차단 (`USER_010`)
  * 현재 비밀번호 검증 (`USER_006`)
  * 새 비밀번호 정책 검증 (`USER_005`)
  * 사용자 상태 검증 (`USER_009`, `USER_008`)

* **PasswordValidator (util)**
  * 공통 비밀번호 정책 검증 로직 분리

* **ErrorCode**
  * `USER_010`: 소셜 로그인 회원 비밀번호 변경 불가

### 2. Swagger 문서

* 성공 및 에러 응답 예시(`200, 400, 401, 403, 410, 404, 500`) 반영
* 소셜 로그인 회원 비밀번호 변경 시 `403 Forbidden (USER_010)` 예시 추가

### 3. 테스트 코드

* **UserServiceTest**
* **UserControllerTest**


## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #102

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
