### PR TITLE
Feat : plan 생성,수정 조건 추가 + todo CRUD 구현 (#119)

### DIFF
--- a/src/main/java/com/back/domain/study/plan/repository/StudyPlanRepository.java
+++ b/src/main/java/com/back/domain/study/plan/repository/StudyPlanRepository.java
@@ -2,11 +2,32 @@ package com.back.domain.study.plan.repository;
 
 import com.back.domain.study.plan.entity.StudyPlan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface StudyPlanRepository extends JpaRepository<StudyPlan, Long> {
     List<StudyPlan> findByUserId(Long userId);
+    /* 시간 겹침 조건:
+     새 계획 시작 시간보다 기존 계획 종료 시간이 늦고 (p.endDate > :newStart),
+     새 계획 종료 시간보다 기존 계획 시작 시간이 빨라야 한다 (p.startDate < :newEnd).
+     (종료 시간 == 새 시작 시간)은 허용
+     */
+    @Query("""
+    SELECT p 
+    FROM StudyPlan p 
+    WHERE p.user.id = :userId 
+      AND (:planIdToExclude IS NULL OR p.id != :planIdToExclude)
+      AND p.endDate > :newStart 
+      AND p.startDate < :newEnd
+""")
+    List<StudyPlan> findByUserIdAndNotIdAndOverlapsTime(
+            Long userId,
+            Long planIdToExclude,
+            LocalDateTime newStart,
+            LocalDateTime newEnd
+    );
 }

--- a/src/main/java/com/back/domain/study/plan/service/StudyPlanService.java
+++ b/src/main/java/com/back/domain/study/plan/service/StudyPlanService.java
@@ -548,7 +548,7 @@ public class StudyPlanService {
             throw new CustomException(ErrorCode.FORBIDDEN);
         }
     }
-
+    // 시작, 종료 날짜 검증
     private void validateDateTime(LocalDateTime startDate, LocalDateTime endDate) {
         if (startDate == null || endDate == null) {
             throw new CustomException(ErrorCode.BAD_REQUEST);
@@ -558,6 +558,7 @@ public class StudyPlanService {
             throw new CustomException(ErrorCode.PLAN_INVALID_TIME_RANGE);
         }
     }
+    //
 
     private void validateRepeatRuleDate(StudyPlan studyPlan, LocalDate untilDate) {
         LocalDate planStartDate = studyPlan.getStartDate().toLocalDate();

--- a/src/main/java/com/back/domain/study/plan/service/StudyPlanService.java
+++ b/src/main/java/com/back/domain/study/plan/service/StudyPlanService.java
@@ -582,16 +582,16 @@ public class StudyPlanService {
 
         for (StudyPlan plan : conflictingOriginalPlans) {
             if (plan.getRepeatRule() == null) {
-                // 2-1. 단발성 계획: 쿼리에서 이미 시간 범위가 겹친다고 걸러졌지만, 최종 확인
+                // 2-1. 단발성 계획 -> 쿼리에서 이미 시간 범위가 겹친다고 걸러졌지만 재확인
                 if (isOverlapping(plan.getStartDate(), plan.getEndDate(), newStart, newEnd)) {
                     throw new CustomException(ErrorCode.PLAN_TIME_CONFLICT);
                 }
             } else {
-                // 2-2. 반복 계획: 기존 헬퍼를 사용해 요청 날짜의 가상 인스턴스를 생성하고 검사
+                // 2-2. 반복 계획 -> 기존 메서드를 사용해 요청 날짜의 가상 인스턴스를 생성하고 검사
                 StudyPlanResponse virtualPlan = createVirtualPlanForDate(plan, newPlanDate);
 
                 if (virtualPlan != null) {
-                    // 가상 인스턴스가 존재하고 (삭제되지 않았고)
+                    // 가상 인스턴스가 존재하고
                     // 해당 인스턴스의 확정된 시간이 새 계획과 겹치는지 최종 확인
                     if (isOverlapping(virtualPlan.getStartDate(), virtualPlan.getEndDate(), newStart, newEnd)) {
                         throw new CustomException(ErrorCode.PLAN_TIME_CONFLICT);

--- a/src/main/java/com/back/domain/study/todo/controller/TodoController.java
+++ b/src/main/java/com/back/domain/study/todo/controller/TodoController.java
@@ -60,7 +60,39 @@ public class TodoController {
     }
 
     // ==================== 수정 ===================
+    // 할 일 내용 수정
+    @PutMapping("/{todoId}")
+    @Operation(summary = "할 일 수정", description = "할 일의 내용과 날짜를 수정합니다.")
+    public ResponseEntity<RsData<TodoResponseDto>> updateTodo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long todoId,
+            @Valid @RequestBody TodoRequestDto requestDto
+    ) {
+        TodoResponseDto response = todoService.updateTodo(userDetails.getUserId(), todoId, requestDto);
+        return ResponseEntity.ok(RsData.success("할 일이 수정되었습니다.", response));
+    }
+
+    // 할 일 완료/미완료 토글
+    @PutMapping("/{todoId}/complete")
+    @Operation(summary = "할 일 완료 상태 토글", description = "할 일의 완료 상태를 변경합니다.")
+    public ResponseEntity<RsData<TodoResponseDto>> toggleTodoComplete(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long todoId
+    ) {
+        TodoResponseDto response = todoService.toggleTodoComplete(userDetails.getUserId(), todoId);
+        return ResponseEntity.ok(RsData.success("할 일 상태가 변경되었습니다.", response));
+    }
 
     // ==================== 삭제 ===================
+    // 할 일 삭제
+    @DeleteMapping("/{todoId}")
+    @Operation(summary = "할 일 삭제", description = "할 일을 삭제합니다.")
+    public ResponseEntity<RsData<Void>> deleteTodo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long todoId
+    ) {
+        todoService.deleteTodo(userDetails.getUserId(), todoId);
+        return ResponseEntity.ok(RsData.success("할 일이 삭제되었습니다."));
+    }
 
 }

--- a/src/main/java/com/back/domain/study/todo/controller/TodoController.java
+++ b/src/main/java/com/back/domain/study/todo/controller/TodoController.java
@@ -1,7 +1,18 @@
 package com.back.domain.study.todo.controller;
 
+import com.back.domain.study.todo.dto.TodoRequestDto;
+import com.back.domain.study.todo.dto.TodoResponseDto;
+import com.back.domain.study.todo.service.TodoService;
+import com.back.global.common.dto.RsData;
+import com.back.global.security.user.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,5 +21,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/todos")
 @Tag(name = "Todo", description = "할 일 관련 API")
 public class TodoController {
+    private final TodoService todoService;
+
+    @PostMapping
+    @Operation(summary = "할 일 생성", description = "새로운 할 일을 생성합니다.")
+    public ResponseEntity<RsData<TodoResponseDto>> createTodo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody TodoRequestDto requestDto
+    ) {
+        TodoResponseDto response = todoService.createTodo(userDetails.getUserId(), requestDto);
+        return ResponseEntity.ok(RsData.success("할 일이 생성되었습니다.", response));
+    }
 
 }

--- a/src/main/java/com/back/domain/study/todo/controller/TodoController.java
+++ b/src/main/java/com/back/domain/study/todo/controller/TodoController.java
@@ -1,0 +1,14 @@
+package com.back.domain.study.todo.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/todos")
+@Tag(name = "Todo", description = "할 일 관련 API")
+public class TodoController {
+
+}

--- a/src/main/java/com/back/domain/study/todo/controller/TodoController.java
+++ b/src/main/java/com/back/domain/study/todo/controller/TodoController.java
@@ -9,12 +9,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TodoController {
     private final TodoService todoService;
 
+    // ==================== 생성 ===================
     @PostMapping
     @Operation(summary = "할 일 생성", description = "새로운 할 일을 생성합니다.")
     public ResponseEntity<RsData<TodoResponseDto>> createTodo(
@@ -32,5 +34,33 @@ public class TodoController {
         TodoResponseDto response = todoService.createTodo(userDetails.getUserId(), requestDto);
         return ResponseEntity.ok(RsData.success("할 일이 생성되었습니다.", response));
     }
+
+    // ==================== 조회 ===================
+    // 특정 날짜 조회
+    @GetMapping
+    @Operation(summary = "할 일 목록 조회", description = "조건에 따라 할 일 목록을 조회합니다. " +
+            "date만 제공시 해당 날짜, startDate와 endDate 제공시 기간별, 아무것도 없으면 전체 조회")
+    public ResponseEntity<RsData<List<TodoResponseDto>>> getTodos(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        List<TodoResponseDto> response = todoService.getTodosByDate(userDetails.getUserId(), date);
+
+        return ResponseEntity.ok(RsData.success("할 일 목록을 조회했습니다.", response));
+    }
+
+    // 사용자의 모든 할 일 조회
+    @GetMapping("/all")
+    @Operation(summary = "모든 할 일 조회", description = "사용자의 모든 할 일을 조회합니다.")
+    public ResponseEntity<RsData<List<TodoResponseDto>>> getAllTodos(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        List<TodoResponseDto> response = todoService.getAllTodos(userDetails.getUserId());
+        return ResponseEntity.ok(RsData.success("모든 할 일을 조회했습니다.", response));
+    }
+
+    // ==================== 수정 ===================
+
+    // ==================== 삭제 ===================
 
 }

--- a/src/main/java/com/back/domain/study/todo/dto/TodoRequestDto.java
+++ b/src/main/java/com/back/domain/study/todo/dto/TodoRequestDto.java
@@ -1,0 +1,15 @@
+package com.back.domain.study.todo.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record TodoRequestDto(
+        @NotBlank(message = "할 일 설명은 필수입니다.")
+        String description,
+        @NotNull(message = "날짜는 필수입니다.")
+        LocalDate date
+) {
+}

--- a/src/main/java/com/back/domain/study/todo/dto/TodoResponseDto.java
+++ b/src/main/java/com/back/domain/study/todo/dto/TodoResponseDto.java
@@ -1,0 +1,23 @@
+package com.back.domain.study.todo.dto;
+
+import com.back.domain.study.todo.entity.Todo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record TodoResponseDto(
+        Long id,
+        String description,
+        boolean isComplete,
+        LocalDate date
+) {
+    // entity -> DTO
+    public static TodoResponseDto from(Todo todo) {
+        return new TodoResponseDto(
+                todo.getId(),
+                todo.getDescription(),
+                todo.isComplete(),
+                todo.getDate()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/study/todo/entity/Todo.java
+++ b/src/main/java/com/back/domain/study/todo/entity/Todo.java
@@ -15,7 +15,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 public class Todo extends BaseEntity {
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -24,5 +24,12 @@ public class Todo extends BaseEntity {
     private String description;
 
     private LocalDate date;
+
+    public Todo(User user, String description, LocalDate date) {
+        this.user = user;
+        this.description = description;
+        this.date = date;
+        this.isComplete = false;
+    }
 
 }

--- a/src/main/java/com/back/domain/study/todo/entity/Todo.java
+++ b/src/main/java/com/back/domain/study/todo/entity/Todo.java
@@ -32,4 +32,11 @@ public class Todo extends BaseEntity {
         this.isComplete = false;
     }
 
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void toggleComplete() {
+        this.isComplete = !this.isComplete;
+    }
 }

--- a/src/main/java/com/back/domain/study/todo/entity/Todo.java
+++ b/src/main/java/com/back/domain/study/todo/entity/Todo.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -22,6 +23,6 @@ public class Todo extends BaseEntity {
 
     private String description;
 
-    private LocalDateTime date;
+    private LocalDate date;
 
 }

--- a/src/main/java/com/back/domain/study/todo/repository/TodoRepository.java
+++ b/src/main/java/com/back/domain/study/todo/repository/TodoRepository.java
@@ -1,9 +1,15 @@
 package com.back.domain.study.todo.repository;
 
 import com.back.domain.study.todo.entity.Todo;
+import com.back.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface TodoRepository extends JpaRepository<Todo, Long> {
+    List<Todo> findByUserIdAndDate(Long userId, LocalDate date);
+    List<Todo> findByUserId(Long userId);
 }

--- a/src/main/java/com/back/domain/study/todo/repository/TodoRepository.java
+++ b/src/main/java/com/back/domain/study/todo/repository/TodoRepository.java
@@ -1,0 +1,9 @@
+package com.back.domain.study.todo.repository;
+
+import com.back.domain.study.todo.entity.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/src/main/java/com/back/domain/study/todo/repository/TodoRepository.java
+++ b/src/main/java/com/back/domain/study/todo/repository/TodoRepository.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TodoRepository extends JpaRepository<Todo, Long> {
     List<Todo> findByUserIdAndDate(Long userId, LocalDate date);
     List<Todo> findByUserId(Long userId);
+    Todo findByIdAndUser(Long id, User user);
 }

--- a/src/main/java/com/back/domain/study/todo/service/TodoService.java
+++ b/src/main/java/com/back/domain/study/todo/service/TodoService.java
@@ -1,0 +1,7 @@
+package com.back.domain.study.todo.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TodoService {
+}

--- a/src/main/java/com/back/domain/study/todo/service/TodoService.java
+++ b/src/main/java/com/back/domain/study/todo/service/TodoService.java
@@ -92,7 +92,7 @@ public class TodoService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
     }
 
-    // 할 일 조회 및 소유권 확인
+    // 할 일 조회 및 사용자 소유 검증
     private Todo findTodoByIdAndUser(Long todoId, User user) {
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));

--- a/src/main/java/com/back/domain/study/todo/service/TodoService.java
+++ b/src/main/java/com/back/domain/study/todo/service/TodoService.java
@@ -1,7 +1,43 @@
 package com.back.domain.study.todo.service;
 
+import com.back.domain.study.todo.dto.TodoRequestDto;
+import com.back.domain.study.todo.dto.TodoResponseDto;
+import com.back.domain.study.todo.entity.Todo;
+import com.back.domain.study.todo.repository.TodoRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.exception.CustomException;
+import com.back.global.exception.ErrorCode;
+import com.back.global.security.user.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TodoService {
+    private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
+
+    // ==================== 생성 ===================
+    public TodoResponseDto createTodo(Long userId, TodoRequestDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Todo todo = new Todo(
+                user,
+                request.description(),
+                request.date()
+        );
+
+        Todo savedTodo = todoRepository.save(todo);
+        return TodoResponseDto.from(savedTodo);
+    }
+
+    // ==================== 조회 ===================
+
+    // ==================== 수정 ===================
+
+    // ==================== 삭제 ===================
 }

--- a/src/main/java/com/back/domain/study/todo/service/TodoService.java
+++ b/src/main/java/com/back/domain/study/todo/service/TodoService.java
@@ -14,6 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -36,7 +40,20 @@ public class TodoService {
     }
 
     // ==================== 조회 ===================
-
+    // 유저의 특정 날짜의 모든 할 일 조회
+    public List<TodoResponseDto> getTodosByDate(Long userId, LocalDate date) {
+        List<Todo> todos = todoRepository.findByUserIdAndDate(userId, date);
+        return todos.stream()
+                .map(TodoResponseDto::from)
+                .collect(Collectors.toList());
+    }
+    // 유저의 전체 할 일 조회
+    public List<TodoResponseDto> getAllTodos(Long userId) {
+        List<Todo> todos = todoRepository.findByUserId(userId);
+        return todos.stream()
+                .map(TodoResponseDto::from)
+                .collect(Collectors.toList());
+    }
     // ==================== 수정 ===================
 
     // ==================== 삭제 ===================

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -43,7 +43,7 @@ public enum ErrorCode {
     PLAN_ORIGINAL_REPEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_004", "해당 날짜에 원본 반복 계획을 찾을 수 없습니다."),
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "PLAN_005", "날짜 형식이 올바르지 않습니다. (YYYY-MM-DD 형식을 사용해주세요)"),
     PLAN_INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "PLAN_006", "시작 시간은 종료 시간보다 빨라야 합니다."),
-    PLAN_CONFLICT(HttpStatus.CONFLICT, "PLAN_007", "이미 존재하는 학습 계획과 시간이 겹칩니다."),
+    PLAN_TIME_CONFLICT(HttpStatus.CONFLICT, "PLAN_007", "이미 존재하는 학습 계획과 시간이 겹칩니다."),
     PLAN_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "PLAN_008", "수정 스위치 로직 탈출. 어떤 경우인지 파악이 필요합니다."),
     REPEAT_INVALID_UNTIL_DATE(HttpStatus.BAD_REQUEST, "REPEAT_001", "반복 계획의 종료 날짜는 시작 날짜 이전일 수 없습니다."),
     REPEAT_BYDAY_REQUIRED(HttpStatus.BAD_REQUEST, "REPEAT_002", "주간 반복 계획의 경우 요일(byDay) 정보가 필요합니다."),

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -43,7 +43,7 @@ public enum ErrorCode {
     PLAN_ORIGINAL_REPEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_004", "해당 날짜에 원본 반복 계획을 찾을 수 없습니다."),
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "PLAN_005", "날짜 형식이 올바르지 않습니다. (YYYY-MM-DD 형식을 사용해주세요)"),
     PLAN_INVALID_TIME_RANGE(HttpStatus.BAD_REQUEST, "PLAN_006", "시작 시간은 종료 시간보다 빨라야 합니다."),
-    PLAN_TIME_CONFLICT(HttpStatus.CONFLICT, "PLAN_007", "이미 존재하는 학습 계획과 시간이 겹칩니다."),
+    PLAN_TIME_CONFLICT(HttpStatus.CONFLICT, "PLAN_007", "이미 존재하는 학습 계획과 시간이 겹칩니다. 기존 종료 시간과 겹치는 경우는 제외됩니다."),
     PLAN_CANNOT_UPDATE(HttpStatus.BAD_REQUEST, "PLAN_008", "수정 스위치 로직 탈출. 어떤 경우인지 파악이 필요합니다."),
     REPEAT_INVALID_UNTIL_DATE(HttpStatus.BAD_REQUEST, "REPEAT_001", "반복 계획의 종료 날짜는 시작 날짜 이전일 수 없습니다."),
     REPEAT_BYDAY_REQUIRED(HttpStatus.BAD_REQUEST, "REPEAT_002", "주간 반복 계획의 경우 요일(byDay) 정보가 필요합니다."),

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -48,6 +48,10 @@ public enum ErrorCode {
     REPEAT_INVALID_UNTIL_DATE(HttpStatus.BAD_REQUEST, "REPEAT_001", "반복 계획의 종료 날짜는 시작 날짜 이전일 수 없습니다."),
     REPEAT_BYDAY_REQUIRED(HttpStatus.BAD_REQUEST, "REPEAT_002", "주간 반복 계획의 경우 요일(byDay) 정보가 필요합니다."),
 
+    // ======================== 투두 관련 ========================
+    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO_001", "존재하지 않는 할 일입니다."),
+    TODO_FORBIDDEN(HttpStatus.FORBIDDEN, "TODO_002", "할 일에 대한 접근 권한이 없습니다."),
+
 
     // ======================== 메시지 관련 ========================
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MESSAGE_001", "존재하지 않는 메시지입니다."),


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- plan 생성 시 기존 계획과 겹치는 시간대인지 검증 로직 추가
- todo CRUD 구현

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

- 쿼리문을 추가하여 기존 조회 기능을 재사용하지 않고 좀 더 성능적으로 개선된 조회 후 검증. 추후 조회 기능 또한 리펙토링 예정
- todo의 경우 내용만 변경하는 방식으로 현재 구현
날짜는 수정하지 못함. 대신 체크박스를 통해 상태변경이 가능하도록 하는 기능 구현
- todo의 경우 생성자 할당 방식이 아닌 from 방식을 채택.
plan은 생성자 할당 방식으로 스타일의 차이가 있음

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #119 

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
