### PR TITLE
refactor: RoomMember 엔티티에서 실시간 상태 필드 제거, redis로 이관 (#96)

### DIFF
--- a/src/main/java/com/back/domain/studyroom/dto/RoomMemberResponse.java
+++ b/src/main/java/com/back/domain/studyroom/dto/RoomMemberResponse.java
@@ -13,18 +13,18 @@ public class RoomMemberResponse {
     private Long userId;
     private String nickname;
     private RoomRole role;
-    private boolean isOnline;
     private LocalDateTime joinedAt;
-    private LocalDateTime lastActiveAt;
+    private LocalDateTime promotedAt;
+    
+    // TODO: isOnline은 Redis에서 조회하여 추가 예정
     
     public static RoomMemberResponse from(RoomMember member) {
         return RoomMemberResponse.builder()
                 .userId(member.getUser().getId())
                 .nickname(member.getUser().getNickname())
                 .role(member.getRole())
-                .isOnline(member.isOnline())
                 .joinedAt(member.getJoinedAt())
-                .lastActiveAt(member.getLastActiveAt() != null ? member.getLastActiveAt() : member.getJoinedAt())
+                .promotedAt(member.getPromotedAt())
                 .build();
     }
 }

--- a/src/main/java/com/back/domain/studyroom/repository/RoomMemberRepository.java
+++ b/src/main/java/com/back/domain/studyroom/repository/RoomMemberRepository.java
@@ -8,8 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long>, RoomMemberRepositoryCustom {
-    /**
-     * WebSocket 연결 ID로 멤버 조회
-     */
-    Optional<RoomMember> findByConnectionId(String connectionId);
+    // 모든 메서드는 RoomMemberRepositoryCustom 인터페이스로 이동
 }

--- a/src/main/java/com/back/domain/studyroom/repository/RoomMemberRepositoryCustom.java
+++ b/src/main/java/com/back/domain/studyroom/repository/RoomMemberRepositoryCustom.java
@@ -20,16 +20,22 @@ public interface RoomMemberRepositoryCustom {
 
     /**
      * 방의 온라인 멤버 조회
+     * TODO: Redis 기반으로 변경 예정
+     * 현재는 DB에 저장된 모든 멤버 반환 (임시)
      */
+    @Deprecated
     List<RoomMember> findOnlineMembersByRoomId(Long roomId);
 
     /**
      * 방의 활성 멤버 수 조회
+     * TODO: Redis 기반으로 변경 예정
      */
+    @Deprecated
     int countActiveMembersByRoomId(Long roomId);
 
     /**
      * 사용자가 참여 중인 모든 방의 멤버십 조회
+     * DB에 저장된 멤버십만 조회 (MEMBER 이상)
      */
     List<RoomMember> findActiveByUserId(Long userId);
 
@@ -60,16 +66,22 @@ public interface RoomMemberRepositoryCustom {
 
     /**
      * 특정 역할의 멤버 수 조회
+     * TODO: Redis 기반으로 변경 예정
      */
+    @Deprecated
     int countByRoomIdAndRole(Long roomId, RoomRole role);
 
     /**
      * 방 퇴장 처리 (벌크 업데이트)
+     * TODO: Redis로 이관 예정, DB에는 멤버십만 유지
      */
+    @Deprecated
     void leaveRoom(Long roomId, Long userId);
 
     /**
      * 방의 모든 멤버를 오프라인 처리 (방 종료 시)
+     * TODO: Redis로 이관 예정
      */
+    @Deprecated
     void disconnectAllMembers(Long roomId);
 }

--- a/src/main/java/com/back/domain/studyroom/repository/RoomRepository.java
+++ b/src/main/java/com/back/domain/studyroom/repository/RoomRepository.java
@@ -39,9 +39,11 @@ public interface RoomRepository extends JpaRepository<Room, Long>, RoomRepositor
     Optional<Room> findByIdAndPassword(@Param("roomId") Long roomId, @Param("password") String password);
 
     // 참가자 수 업데이트
+    // TODO: Redis 기반으로 변경 예정 - 현재는 사용하지 않음
+    @Deprecated
     @Modifying
     @Query("UPDATE Room r SET r.currentParticipants = " +
-           "(SELECT COUNT(rm) FROM RoomMember rm WHERE rm.room.id = r.id AND rm.isOnline = true) " +
+           "(SELECT COUNT(rm) FROM RoomMember rm WHERE rm.room.id = r.id) " +
            "WHERE r.id = :roomId")
     void updateCurrentParticipants(@Param("roomId") Long roomId);
 }

--- a/src/main/java/com/back/domain/studyroom/repository/RoomRepositoryImpl.java
+++ b/src/main/java/com/back/domain/studyroom/repository/RoomRepositoryImpl.java
@@ -76,9 +76,9 @@ public class RoomRepositoryImpl implements RoomRepositoryCustom {
 
     /**
      * 사용자가 참여 중인 방 조회
-     *  조회 조건:
-     * - 특정 사용자가 멤버로 등록된 방
-     * - 현재 온라인 상태인 방만
+     * 조회 조건:
+     * - 특정 사용자가 멤버로 등록된 방 (DB에 저장된 멤버십)
+     * TODO: Redis에서 온라인 상태 확인하도록 변경
      * @param userId 사용자 ID
      * @return 참여 중인 방 목록
      */
@@ -88,10 +88,7 @@ public class RoomRepositoryImpl implements RoomRepositoryCustom {
                 .selectFrom(room)
                 .leftJoin(room.createdBy, user).fetchJoin()  // N+1 방지
                 .join(room.roomMembers, roomMember)          // 멤버 조인
-                .where(
-                        roomMember.user.id.eq(userId),
-                        roomMember.isOnline.eq(true)
-                )
+                .where(roomMember.user.id.eq(userId))
                 .fetch();
     }
 

--- a/src/main/java/com/back/global/websocket/webrtc/service/WebRTCSignalValidator.java
+++ b/src/main/java/com/back/global/websocket/webrtc/service/WebRTCSignalValidator.java
@@ -32,15 +32,17 @@ public class WebRTCSignalValidator {
         }
 
         // 2. 발신자가 방에 속해있는지 확인
+        // TODO: Redis에서 온라인 상태 확인하도록 변경
         Optional<RoomMember> fromMember = roomMemberRepository.findByRoomIdAndUserId(roomId, fromUserId);
-        if (fromMember.isEmpty() || !fromMember.get().isOnline()) {
+        if (fromMember.isEmpty()) {
             log.warn("방에 속하지 않은 사용자의 시그널 전송 시도 - roomId: {}, userId: {}", roomId, fromUserId);
             throw new CustomException(ErrorCode.NOT_ROOM_MEMBER);
         }
 
         // 3. 수신자가 같은 방에 속해있는지 확인
+        // TODO: Redis에서 온라인 상태 확인하도록 변경
         Optional<RoomMember> targetMember = roomMemberRepository.findByRoomIdAndUserId(roomId, targetUserId);
-        if (targetMember.isEmpty() || !targetMember.get().isOnline()) {
+        if (targetMember.isEmpty()) {
             log.warn("수신자가 방에 없거나 오프라인 상태 - roomId: {}, targetUserId: {}", roomId, targetUserId);
             throw new CustomException(ErrorCode.NOT_ROOM_MEMBER);
         }
@@ -50,9 +52,10 @@ public class WebRTCSignalValidator {
 
     // 미디어 상태 변경 검증
     public void validateMediaStateChange(Long roomId, Long userId) {
+        // TODO: Redis에서 온라인 상태 확인하도록 변경
         Optional<RoomMember> member = roomMemberRepository.findByRoomIdAndUserId(roomId, userId);
 
-        if (member.isEmpty() || !member.get().isOnline()) {
+        if (member.isEmpty()) {
             log.warn("방에 속하지 않은 사용자의 미디어 상태 변경 시도 - roomId: {}, userId: {}", roomId, userId);
             throw new CustomException(ErrorCode.NOT_ROOM_MEMBER);
         }

--- a/src/test/java/com/back/domain/studyroom/service/RoomServiceTest.java
+++ b/src/test/java/com/back/domain/studyroom/service/RoomServiceTest.java
@@ -185,7 +185,7 @@ class RoomServiceTest {
     @DisplayName("방 나가기 - 성공")
     void leaveRoom_Success() {
         // given
-        testMember.updateOnlineStatus(true);
+        // TODO: Redis 통합 후 온라인 상태 체크 추가 예정
         given(roomRepository.findById(1L)).willReturn(Optional.of(testRoom));
         given(roomMemberRepository.findByRoomIdAndUserId(1L, 1L)).willReturn(Optional.of(testMember));
 
@@ -303,7 +303,7 @@ class RoomServiceTest {
     void terminateRoom_Success() {
         // given
         given(roomRepository.findById(1L)).willReturn(Optional.of(testRoom));
-        willDoNothing().given(roomMemberRepository).disconnectAllMembers(1L);
+        // disconnectAllMembers는 더 이상 호출되지 않음 (Redis로 이관 예정)
 
         // when
         roomService.terminateRoom(1L, 1L);
@@ -311,7 +311,7 @@ class RoomServiceTest {
         // then
         assertThat(testRoom.getStatus()).isEqualTo(RoomStatus.TERMINATED);
         assertThat(testRoom.isActive()).isFalse();
-        verify(roomMemberRepository, times(1)).disconnectAllMembers(1L);
+        // verify 제거: disconnectAllMembers는 더 이상 호출되지 않음
     }
 
     @Test


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요
Redis 연결을 위해 `RoomMember` 엔티티를 수정하던 중, RTC/채팅 관련 최신 코드가 병합되면서 충돌 및 에러가 지속적으로 발생했습니다.  
따라서 Redis까지 연동했던 작업을 초기화하고, **DB ↔ Redis 역할 분리까지만 진행**했습니다.  

주요 변경 사항:
- `RoomMember` 엔티티에서 **실시간 상태 관련 필드 제거** (Redis 이관을 위해)
- 관련 테스트 케이스 수정
- 향후 Redis 마이그레이션 파트는 `// TODO` 주석으로 처리

---

## 🔨 작업 내용

### 1. RoomMember 엔티티 리팩토링
**제거된 필드**
- `isOnline`: 온라인 상태 → Redis 이관 예정
- `connectionId`: WebSocket 연결 ID → Redis 이관 예정
- `lastHeartbeat`: 마지막 하트비트 시간 → Redis 이관 예정
- `lastActiveAt`: 마지막 활동 시간 → Redis 이관 예정

**추가된 필드**
- `promotedAt`: MEMBER 이상으로 권한 변경된 시간

**의미 변경**
- `joinedAt`: 기존 = 방 입장 시간  
  변경 후 = MEMBER 이상으로 승격된 시간 (Member 이상부터만 db에 권한에 대한 정보로써 저장하기 위해)

---

### 2. Repository 수정
- `RoomMemberRepository.findByConnectionId()` 제거
- `RoomMemberRepositoryImpl.leaveRoom()` → `@Deprecated`
- `RoomMemberRepositoryImpl.disconnectAllMembers()` → `@Deprecated`
- `RoomRepository.updateCurrentParticipants()` → `rm.isOnline = true` 조건 제거
- `RoomRepositoryImpl.findRoomsByUserId()` → `isOnline` 조건 제거

---

### 3. Service 로직 수정
- `RoomService.joinRoom()` → `isOnline` 체크 및 `updateOnlineStatus()` 호출 제거
- `RoomService.leaveRoom()` → `member.leave()` 호출 제거 + Redis 이관 TODO 추가
- `RoomService.terminateRoom()` → `disconnectAllMembers()` 주석 처리
- `RoomService.kickMember()` → `targetMember.leave()` 호출 제거

---

### 4. Validator 수정
- `WebRTCSignalValidator`: 온라인 상태 검증 로직 제거

---

### 5. DTO 수정
- `RoomMemberResponse` → `isOnline`, `lastActiveAt` 제거 / `promotedAt` 추가

---

### 6. 테스트 수정
- `RoomServiceTest`: `updateOnlineStatus()` 호출 제거, `disconnectAllMembers` 검증 제거
- `WebRTCSignalValidatorTest`: 온라인/오프라인 관련 테스트 제거 및 간소화

---

## 🔗 관련 이슈
Closes #96  

---

## 📝 참고 사항
- DB에는 **MEMBER, SUB_HOST, HOST만 저장**
- VISITOR는 **Redis에서만 관리** (DB 저장 X)
- 명세서 변경 예정:
  - `RoomMemberResponse`: `isOnline`, `lastActiveAt` 제거
- 현재는 `updateCurrentParticipants()`: Redis 연결 전이라 온라인 구분 없이 전체 인원 기준으로 처리로 변경한 상태입니다.
---

### *바로 진행할 다음 작업 예정*
- Redis 기반 온라인 상태 관리 구현
- WebSocket 연결 시 Redis에 세션 정보 저장
- Heartbeat 로직을 Redis 기반으로 전환
- 방 참가자 수 실시간 업데이트 로직 구현


---

## ✅ 체크리스트
- [x] 기능 동작 확인  
- [x] 테스트 코드 작성  
- [ ] 문서/주석 최신화  
