### PR TITLE
Feat: 게시글 다건/단건 조회 API 구현 (#131)

### DIFF
--- a/src/main/java/com/back/domain/board/controller/PostController.java
+++ b/src/main/java/com/back/domain/board/controller/PostController.java
@@ -1,12 +1,14 @@
 package com.back.domain.board.controller;
 
-import com.back.domain.board.dto.PostRequest;
-import com.back.domain.board.dto.PostResponse;
+import com.back.domain.board.dto.*;
 import com.back.domain.board.service.PostService;
 import com.back.global.common.dto.RsData;
 import com.back.global.security.user.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -29,6 +31,37 @@ public class PostController implements PostControllerDocs {
                 .status(HttpStatus.CREATED)
                 .body(RsData.success(
                         "게시글이 생성되었습니다.",
+                        response
+                ));
+    }
+
+    // 게시글 다건 조회
+    @GetMapping
+    public ResponseEntity<RsData<PageResponse<PostListResponse>>> getPosts(
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String searchType,
+            @RequestParam(required = false) Long categoryId
+    ) {
+        PageResponse<PostListResponse> response = postService.getPosts(keyword, searchType, categoryId, pageable);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success(
+                        "게시글 목록이 조회되었습니다.",
+                        response
+                ));
+    }
+
+    // 게시글 단건 조회
+    @GetMapping("/{postId}")
+    public ResponseEntity<RsData<PostDetailResponse>> getPost(
+            @PathVariable Long postId
+    ) {
+        PostDetailResponse response = postService.getPost(postId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success(
+                        "게시글이 조회되었습니다.",
                         response
                 ));
     }

--- a/src/main/java/com/back/domain/board/controller/PostControllerDocs.java
+++ b/src/main/java/com/back/domain/board/controller/PostControllerDocs.java
@@ -1,7 +1,6 @@
 package com.back.domain.board.controller;
 
-import com.back.domain.board.dto.PostRequest;
-import com.back.domain.board.dto.PostResponse;
+import com.back.domain.board.dto.*;
 import com.back.global.common.dto.RsData;
 import com.back.global.security.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,9 +9,13 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Post API", description = "게시글 관련 API")
 public interface PostControllerDocs {
@@ -143,5 +146,152 @@ public interface PostControllerDocs {
     ResponseEntity<RsData<PostResponse>> createPost(
             @RequestBody PostRequest request,
             @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "게시글 목록 조회",
+            description = "모든 사용자가 게시글 목록을 조회할 수 있습니다. (로그인 불필요)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "게시글 목록이 조회되었습니다.",
+                                      "data": {
+                                        "items": [
+                                          {
+                                            "postId": 1,
+                                            "author": { "id": 10, "nickname": "홍길동" },
+                                            "title": "첫 글",
+                                            "categories": [{ "id": 1, "name": "공지사항" }],
+                                            "likeCount": 5,
+                                            "bookmarkCount": 2,
+                                            "commentCount": 3,
+                                            "createdAt": "2025-09-30T10:15:30",
+                                            "updatedAt": "2025-09-30T10:20:00"
+                                          }
+                                        ],
+                                        "page": 0,
+                                        "size": 10,
+                                        "totalElements": 25,
+                                        "totalPages": 3,
+                                        "last": false
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (페이징 파라미터 오류 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_400",
+                                      "message": "잘못된 요청입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<PageResponse<PostListResponse>>> getPosts(
+            @PageableDefault(sort = "createdAt") Pageable pageable,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String searchType,
+            @RequestParam(required = false) Long categoryId
+    );
+
+
+    @Operation(
+            summary = "게시글 단건 조회",
+            description = "모든 사용자가 특정 게시글의 상세 정보를 조회할 수 있습니다. (로그인 불필요)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 단건 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "게시글이 조회되었습니다.",
+                                      "data": {
+                                        "postId": 101,
+                                        "author": { "id": 5, "nickname": "홍길동" },
+                                        "title": "첫 번째 게시글",
+                                        "content": "안녕하세요, 첫 글입니다!",
+                                        "categories": [
+                                          { "id": 1, "name": "공지사항" },
+                                          { "id": 2, "name": "자유게시판" }
+                                        ],
+                                        "likeCount": 10,
+                                        "bookmarkCount": 2,
+                                        "commentCount": 3,
+                                        "createdAt": "2025-09-22T10:30:00",
+                                        "updatedAt": "2025-09-22T10:30:00"
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "POST_001",
+                                      "message": "존재하지 않는 게시글입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<PostDetailResponse>> getPost(
+            @PathVariable Long postId
     );
 }

--- a/src/main/java/com/back/domain/board/dto/PageResponse.java
+++ b/src/main/java/com/back/domain/board/dto/PageResponse.java
@@ -1,0 +1,36 @@
+package com.back.domain.board.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+/**
+ * 페이지 응답 DTO
+ *
+ * @param items         목록 데이터
+ * @param page          현재 페이지 번호
+ * @param size          페이지 크기
+ * @param totalElements 전체 요소 수
+ * @param totalPages    전체 페이지 수
+ * @param last          마지막 페이지 여부
+ * @param <T>           제네릭 타입
+ */
+public record PageResponse<T>(
+        List<T> items,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
+) {
+    public static <T> PageResponse<T> from(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/board/dto/PostDetailResponse.java
+++ b/src/main/java/com/back/domain/board/dto/PostDetailResponse.java
@@ -1,0 +1,50 @@
+package com.back.domain.board.dto;
+
+import com.back.domain.board.entity.Post;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 게시글 상세 응답 DTO
+ *
+ * @param postId        게시글 ID
+ * @param author        작성자 정보
+ * @param title         게시글 제목
+ * @param content       게시글 내용
+ * @param categories    게시글 카테고리 목록
+ * @param likeCount     좋아요 수
+ * @param bookmarkCount 북마크 수
+ * @param commentCount  댓글 수
+ * @param createdAt     게시글 생성 일시
+ * @param updatedAt     게시글 수정 일시
+ */
+public record PostDetailResponse(
+        Long postId,
+        AuthorResponse author,
+        String title,
+        String content,
+        List<CategoryResponse> categories,
+        long likeCount,
+        long bookmarkCount,
+        long commentCount,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PostDetailResponse from(Post post) {
+        return new PostDetailResponse(
+                post.getId(),
+                AuthorResponse.from(post.getUser()),
+                post.getTitle(),
+                post.getContent(),
+                post.getCategories().stream()
+                        .map(CategoryResponse::from)
+                        .toList(),
+                post.getPostLikes().size(),
+                post.getPostBookmarks().size(),
+                post.getComments().size(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/board/dto/PostListResponse.java
+++ b/src/main/java/com/back/domain/board/dto/PostListResponse.java
@@ -1,0 +1,77 @@
+package com.back.domain.board.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 게시글 목록 응답 DTO
+ */
+@Getter
+public class PostListResponse {
+    private final Long postId;
+    private final AuthorResponse author;
+    private final String title;
+    private final long likeCount;
+    private final long bookmarkCount;
+    private final long commentCount;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    @Setter
+    private List<CategoryResponse> categories;
+
+    @QueryProjection
+    public PostListResponse(Long postId,
+                            AuthorResponse author,
+                            String title,
+                            List<CategoryResponse> categories,
+                            long likeCount,
+                            long bookmarkCount,
+                            long commentCount,
+                            LocalDateTime createdAt,
+                            LocalDateTime updatedAt) {
+        this.postId = postId;
+        this.author = author;
+        this.title = title;
+        this.categories = categories;
+        this.likeCount = likeCount;
+        this.bookmarkCount = bookmarkCount;
+        this.commentCount = commentCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    /**
+     * 작성자 응답 DTO
+     */
+    @Getter
+    public static class AuthorResponse {
+        private final Long id;
+        private final String nickname;
+
+        @QueryProjection
+        public AuthorResponse(Long userId, String nickname) {
+            this.id = userId;
+            this.nickname = nickname;
+        }
+    }
+
+    /**
+     * 카테고리 응답 DTO
+     */
+    @Getter
+    public static class CategoryResponse {
+        private final Long id;
+        private final String name;
+
+        @QueryProjection
+        public CategoryResponse(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/com/back/domain/board/repository/PostRepository.java
+++ b/src/main/java/com/back/domain/board/repository/PostRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 }

--- a/src/main/java/com/back/domain/board/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/back/domain/board/repository/PostRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.back.domain.board.repository;
+
+import com.back.domain.board.dto.PostListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+    Page<PostListResponse> searchPosts(String keyword, String searchType, Long categoryId, Pageable pageable);
+}

--- a/src/main/java/com/back/domain/board/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/back/domain/board/repository/PostRepositoryImpl.java
@@ -1,0 +1,224 @@
+package com.back.domain.board.repository;
+
+import com.back.domain.board.dto.PostListResponse;
+import com.back.domain.board.dto.QPostListResponse;
+import com.back.domain.board.dto.QPostListResponse_AuthorResponse;
+import com.back.domain.board.dto.QPostListResponse_CategoryResponse;
+import com.back.domain.board.entity.*;
+import com.back.domain.user.entity.QUser;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 게시글 다건 검색
+     *
+     * @param keyword    검색 키워드
+     * @param searchType 검색 타입(title/content/author/전체)
+     * @param categoryId 카테고리 ID 필터 (nullable)
+     * @param pageable   페이징 + 정렬 조건
+     */
+    @Override
+    public Page<PostListResponse> searchPosts(String keyword, String searchType, Long categoryId, Pageable pageable) {
+        // 검색 조건 생성
+        BooleanBuilder where = buildWhere(keyword, searchType, categoryId);
+
+        // 정렬 조건 생성
+        List<OrderSpecifier<?>> orders = buildOrderSpecifiers(pageable);
+
+        // 메인 게시글 쿼리 실행
+        List<PostListResponse> results = fetchPosts(where, orders, pageable);
+
+        // 카테고리 조회 후 DTO에 주입
+        injectCategories(results);
+
+        // 전체 카운트 조회
+        long total = countPosts(where, categoryId);
+
+        // 결과를 Page로 감싸서 반환
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    /**
+     * 검색 조건 생성
+     * - keyword + searchType(title/content/author)에 따라 동적 조건 추가
+     * - categoryId가 주어지면 카테고리 필터 조건 추가
+     */
+    private BooleanBuilder buildWhere(String keyword, String searchType, Long categoryId) {
+        QPost post = QPost.post;
+        QPostCategoryMapping categoryMapping = QPostCategoryMapping.postCategoryMapping;
+
+        BooleanBuilder where = new BooleanBuilder();
+
+        // 검색 조건 추가
+        if (keyword != null && !keyword.isBlank()) {
+            switch (searchType) {
+                case "title" -> where.and(post.title.containsIgnoreCase(keyword));
+                case "content" -> where.and(post.content.containsIgnoreCase(keyword));
+                case "author" -> where.and(post.user.username.containsIgnoreCase(keyword));
+                default -> where.and(
+                        post.title.containsIgnoreCase(keyword)
+                                .or(post.content.containsIgnoreCase(keyword))
+                                .or(post.user.username.containsIgnoreCase(keyword))
+                );
+            }
+        }
+
+        // 카테고리 필터링
+        if (categoryId != null) {
+            where.and(categoryMapping.category.id.eq(categoryId));
+        }
+
+        return where;
+    }
+
+    /**
+     * 정렬 처리 빌더
+     * - Pageable의 Sort 정보 기반으로 OrderSpecifier 생성
+     * - likeCount/bookmarkCount/commentCount -> countDistinct() 기준 정렬
+     * - 그 외 속성 -> Post 엔티티 필드 기준 정렬
+     */
+    private List<OrderSpecifier<?>> buildOrderSpecifiers(Pageable pageable) {
+        QPost post = QPost.post;
+        QPostLike postLike = QPostLike.postLike;
+        QPostBookmark postBookmark = QPostBookmark.postBookmark;
+        QComment comment = QComment.comment;
+
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+        PathBuilder<Post> entityPath = new PathBuilder<>(Post.class, post.getMetadata());
+
+        // 정렬 조건 추가
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String prop = order.getProperty();
+            switch (prop) {
+                case "likeCount" -> orders.add(new OrderSpecifier<>(direction, postLike.id.countDistinct()));
+                case "bookmarkCount" -> orders.add(new OrderSpecifier<>(direction, postBookmark.id.countDistinct()));
+                case "commentCount" -> orders.add(new OrderSpecifier<>(direction, comment.id.countDistinct()));
+                default ->
+                        orders.add(new OrderSpecifier<>(direction, entityPath.getComparable(prop, Comparable.class)));
+            }
+        }
+
+        return orders;
+    }
+
+    /**
+     * 게시글 조회 (메인 쿼리)
+     * - Post + User join
+     * - 좋아요, 북마크, 댓글 countDistinct() 집계
+     * - groupBy(post.id, user.id, userProfie.nickname)
+     * - Pageable offset/limit 적용
+     */
+    private List<PostListResponse> fetchPosts(BooleanBuilder where, List<OrderSpecifier<?>> orders, Pageable pageable) {
+        QPost post = QPost.post;
+        QUser user = QUser.user;
+        QPostLike postLike = QPostLike.postLike;
+        QPostBookmark postBookmark = QPostBookmark.postBookmark;
+        QComment comment = QComment.comment;
+
+        return queryFactory
+                .select(new QPostListResponse(
+                        post.id,
+                        new QPostListResponse_AuthorResponse(user.id, user.userProfile.nickname),
+                        post.title,
+                        null,   // 카테고리는 나중에 주입
+                        postLike.id.countDistinct(),
+                        postBookmark.id.countDistinct(),
+                        comment.id.countDistinct(),
+                        post.createdAt,
+                        post.updatedAt
+                ))
+                .from(post)
+                .leftJoin(post.user, user)
+                .leftJoin(post.postLikes, postLike)
+                .leftJoin(post.postBookmarks, postBookmark)
+                .leftJoin(post.comments, comment)
+                .where(where)
+                .groupBy(post.id, user.id, user.userProfile.nickname)
+                .orderBy(orders.toArray(new OrderSpecifier[0]))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    /**
+     * 카테고리 일괄 조회 & 매핑
+     * - postId 목록을 모아 IN 쿼리 실행
+     * - 결과를 Map<postId, List<CategoryResponse>>로 변환
+     * - 각 PostListResponse DTO에 categories 주입
+     */
+    private void injectCategories(List<PostListResponse> results) {
+        if (results.isEmpty()) return;
+
+        QPostCategoryMapping categoryMapping = QPostCategoryMapping.postCategoryMapping;
+
+        // postId 목록 생성
+        List<Long> postIds = results.stream()
+                .map(PostListResponse::getPostId)
+                .toList();
+
+        // 해당하는 카테고리 정보 조회
+        List<Tuple> categoryTuples = queryFactory
+                .select(
+                        categoryMapping.post.id,
+                        new QPostListResponse_CategoryResponse(categoryMapping.category.id, categoryMapping.category.name)
+                )
+                .from(categoryMapping)
+                .where(categoryMapping.post.id.in(postIds))
+                .fetch();
+
+        // Map<postId, List<CategoryResponse>>로 변환
+        Map<Long, List<PostListResponse.CategoryResponse>> categoryMap = categoryTuples.stream()
+                .collect(Collectors.groupingBy(
+                        tuple -> Objects.requireNonNull(tuple.get(categoryMapping.post.id)),
+                        Collectors.mapping(t -> t.get(1, PostListResponse.CategoryResponse.class), Collectors.toList())
+                ));
+
+        // categories 주입
+        results.forEach(r -> r.setCategories(categoryMap.getOrDefault(r.getPostId(), List.of())));
+    }
+
+    /**
+     * 전체 게시글 개수 조회
+     * - 조건에 맞는 게시글 총 개수를 가져옴
+     * - categoryId 필터가 있으면 postCategoryMapping join 포함
+     */
+    private long countPosts(BooleanBuilder where, Long categoryId) {
+        QPost post = QPost.post;
+        QPostCategoryMapping categoryMapping = QPostCategoryMapping.postCategoryMapping;
+
+        // 카운트 쿼리
+        JPAQuery<Long> countQuery = queryFactory
+                .select(post.countDistinct())
+                .from(post);
+
+        // 카테고리 필터링
+        if (categoryId != null) {
+            countQuery.leftJoin(post.postCategoryMappings, categoryMapping);
+        }
+
+        Long total = countQuery.where(where).fetchOne();
+
+        return total != null ? total : 0L;
+    }
+}

--- a/src/main/java/com/back/domain/board/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/back/domain/board/repository/PostRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -19,10 +20,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -141,7 +139,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         post.id,
                         new QPostListResponse_AuthorResponse(user.id, user.userProfile.nickname),
                         post.title,
-                        null,   // 카테고리는 나중에 주입
+                        Expressions.constant(Collections.emptyList()),   // 카테고리는 나중에 주입
                         postLike.id.countDistinct(),
                         postBookmark.id.countDistinct(),
                         comment.id.countDistinct(),

--- a/src/main/java/com/back/domain/board/service/PostService.java
+++ b/src/main/java/com/back/domain/board/service/PostService.java
@@ -1,7 +1,6 @@
 package com.back.domain.board.service;
 
-import com.back.domain.board.dto.PostRequest;
-import com.back.domain.board.dto.PostResponse;
+import com.back.domain.board.dto.*;
 import com.back.domain.board.entity.Post;
 import com.back.domain.board.entity.PostCategory;
 import com.back.domain.board.repository.PostCategoryRepository;
@@ -11,6 +10,8 @@ import com.back.domain.user.repository.UserRepository;
 import com.back.global.exception.CustomException;
 import com.back.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,5 +53,31 @@ public class PostService {
         // Post 저장 및 응답 반환
         Post saved = postRepository.save(post);
         return PostResponse.from(saved);
+    }
+
+    /**
+     * 게시글 다건 조회 서비스
+     * 1. Post 검색 (키워드, 검색타입, 카테고리, 페이징)
+     * 2. PageResponse 반환
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<PostListResponse> getPosts(String keyword, String searchType, Long categoryId, Pageable pageable) {
+        Page<PostListResponse> posts = postRepository.searchPosts(keyword, searchType, categoryId, pageable);
+        return PageResponse.from(posts);
+    }
+
+    /**
+     * 게시글 단건 조회 서비스
+     * 1. Post 조회
+     * 2. PostResponse 반환
+     */
+    @Transactional(readOnly = true)
+    public PostDetailResponse getPost(Long postId) {
+        // Post 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 응답 반환
+        return PostDetailResponse.from(post);
     }
 }

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() // CORS Preflight 요청 허용
                                 .requestMatchers("/api/auth/**", "/oauth2/**", "/login/oauth2/**").permitAll()
                                 .requestMatchers("api/ws/**", "/ws/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                                 .requestMatchers("/api/rooms/*/messages/**").permitAll()  //스터디 룸 내에 잡혀있어 있는 채팅 관련 전체 허용
                                 //.requestMatchers("/api/rooms/RoomChatApiControllerTest").permitAll() // 테스트용 임시 허용
                                 .requestMatchers("/","/swagger-ui/**", "/v3/api-docs/**").permitAll() // Swagger 허용


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

* 모든 사용자가 접근 가능한 **게시글 목록 조회** 및 **게시글 단건 조회** API를 구현했습니다.
* 검색 조건, 페이징, 카테고리 필터링을 지원하고 Swagger 문서화를 포함합니다.

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

1. **Controller**

   * `PostController`
     * `GET /api/posts` : 게시글 목록 조회
     * `GET /api/posts/{postId}` : 게시글 단건 조회

2. **Service**

   * `PostService#getPosts`
     * 키워드, 검색 타입, 카테고리, 페이징 조건으로 게시글 목록 조회
     * 결과를 `PageResponse<PostListResponse>`로 변환 후 반환

   * `PostService#getPost`
     * 게시글 단건 조회 후 `PostDetailResponse` 반환
     * 존재하지 않는 경우 `POST_NOT_FOUND` 예외 처리

3. **Repository**

   * `PostRepositoryImpl`
     * `searchPosts` 메서드 구현 (QueryDSL 기반)
     * 검색 조건(where), 정렬(order), 카테고리 주입(injectCategories), 전체 카운트 처리 포함

4. **DTO**

   * `PageResponse<T>` : 공통 페이지 응답 DTO
   * `PostListResponse` : 게시글 목록 조회 응답 DTO (작성자, 카테고리, 좋아요/북마크/댓글 수 포함)
   * `PostDetailResponse` : 게시글 단건 조회 응답 DTO

5. **Swagger 문서 (`PostControllerDocs`)**

   * `게시글 목록 조회` API 문서화
   * `게시글 단건 조회` API 문서화
   * 성공/실패 응답 JSON 예시 추가

6. **Test**

   * `PostServiceTest`
     * 단건 조회 성공/실패 테스트
     * 다건 조회 페이징 테스트

   * `PostControllerTest`
     * `GET /api/posts` 성공 테스트
     * `GET /api/posts/{postId}` 성공/실패 테스트

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #{이슈 번호}

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 다건 조회 시 N+1 문제가 발생하지 않도록 처리했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
