### PR TITLE
Feat: 게시글 수정 및 삭제 API 구현 (#131)

### DIFF
--- a/src/main/java/com/back/domain/board/controller/PostController.java
+++ b/src/main/java/com/back/domain/board/controller/PostController.java
@@ -65,4 +65,20 @@ public class PostController implements PostControllerDocs {
                         response
                 ));
     }
+
+    // 게시글 수정
+    @PutMapping("/{postId}")
+    public ResponseEntity<RsData<PostResponse>> updatePost(
+            @PathVariable Long postId,
+            @RequestBody @Valid PostRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        PostResponse response = postService.updatePost(postId, request, user.getUserId());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success(
+                        "게시글이 수정되었습니다.",
+                        response
+                ));
+    }
 }

--- a/src/main/java/com/back/domain/board/controller/PostController.java
+++ b/src/main/java/com/back/domain/board/controller/PostController.java
@@ -81,4 +81,19 @@ public class PostController implements PostControllerDocs {
                         response
                 ));
     }
+
+    // 게시글 삭제
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<RsData<Void>> deletePost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        postService.deletePost(postId, user.getUserId());
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success(
+                        "게시글이 삭제되었습니다.",
+                        null
+                ));
+    }
 }

--- a/src/main/java/com/back/domain/board/controller/PostControllerDocs.java
+++ b/src/main/java/com/back/domain/board/controller/PostControllerDocs.java
@@ -294,4 +294,148 @@ public interface PostControllerDocs {
     ResponseEntity<RsData<PostDetailResponse>> getPost(
             @PathVariable Long postId
     );
+
+    @Operation(
+            summary = "게시글 수정",
+            description = "로그인한 사용자가 자신의 게시글을 수정합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 수정 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "게시글이 수정되었습니다.",
+                                      "data": {
+                                        "postId": 101,
+                                        "author": {
+                                          "id": 5,
+                                          "nickname": "홍길동"
+                                        },
+                                        "title": "수정된 게시글",
+                                        "content": "안녕하세요, 수정했습니다!",
+                                        "categories": [
+                                          { "id": 1, "name": "공지사항" },
+                                          { "id": 2, "name": "자유게시판" }
+                                        ],
+                                        "createdAt": "2025-09-22T10:30:00",
+                                        "updatedAt": "2025-09-22T10:30:00"
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (필드 누락 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_400",
+                                      "message": "잘못된 요청입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 없음/만료/잘못됨)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "토큰 없음", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_001",
+                                              "message": "인증이 필요합니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "잘못된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_002",
+                                              "message": "유효하지 않은 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "만료된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_004",
+                                              "message": "만료된 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (작성자 아님)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "POST_002",
+                                      "message": "게시글 작성자만 수정/삭제할 수 있습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글 또는 카테고리",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "존재하지 않는 게시글", value = """
+                                            {
+                                              "success": false,
+                                              "code": "POST_001",
+                                              "message": "존재하지 않는 게시글입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "존재하지 않는 카테고리", value = """
+                                            {
+                                              "success": false,
+                                              "code": "POST_003",
+                                              "message": "존재하지 않는 카테고리입니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<PostResponse>> updatePost(
+            @PathVariable Long postId,
+            @RequestBody PostRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    );
 }

--- a/src/main/java/com/back/domain/board/controller/PostControllerDocs.java
+++ b/src/main/java/com/back/domain/board/controller/PostControllerDocs.java
@@ -438,4 +438,123 @@ public interface PostControllerDocs {
             @RequestBody PostRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     );
+
+    @Operation(
+            summary = "게시글 삭제",
+            description = "로그인한 사용자가 자신의 게시글을 삭제합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "게시글 삭제 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "게시글이 삭제되었습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (필드 누락 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_400",
+                                      "message": "잘못된 요청입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 없음/만료/잘못됨)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "토큰 없음", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_001",
+                                              "message": "인증이 필요합니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "잘못된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_002",
+                                              "message": "유효하지 않은 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "만료된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_004",
+                                              "message": "만료된 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "권한 없음 (작성자 아님)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "POST_002",
+                                      "message": "게시글 작성자만 수정/삭제할 수 있습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "POST_001",
+                                      "message": "존재하지 않는 게시글입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<Void>> deletePost(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails user
+    );
 }

--- a/src/main/java/com/back/domain/board/entity/Post.java
+++ b/src/main/java/com/back/domain/board/entity/Post.java
@@ -41,6 +41,12 @@ public class Post extends BaseEntity {
     }
 
     // -------------------- 비즈니스 메서드 --------------------
+    // 게시글 업데이트
+    public void update(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
     // 카테고리 업데이트
     public void updateCategories(List<PostCategory> categories) {
         this.postCategoryMappings.clear();

--- a/src/main/java/com/back/domain/board/service/PostService.java
+++ b/src/main/java/com/back/domain/board/service/PostService.java
@@ -111,4 +111,24 @@ public class PostService {
         // 응답 반환
         return PostResponse.from(post);
     }
+
+    /**
+     * 게시글 삭제 서비스
+     * 1. Post 조회
+     * 2. 작성자 검증
+     * 3. Post 삭제
+     */
+    public void deletePost(Long postId, Long userId) {
+        // Post 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 작성자 검증
+        if (!post.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.POST_NO_PERMISSION);
+        }
+
+        // Post 삭제
+        postRepository.delete(post);
+    }
 }

--- a/src/main/java/com/back/domain/board/service/PostService.java
+++ b/src/main/java/com/back/domain/board/service/PostService.java
@@ -80,4 +80,35 @@ public class PostService {
         // 응답 반환
         return PostDetailResponse.from(post);
     }
+
+    /**
+     * 게시글 수정 서비스
+     * 1. Post 조회
+     * 2. 작성자 검증
+     * 3. Post 업데이트 (제목, 내용, 카테고리)
+     * 4. PostResponse 반환
+     */
+    public PostResponse updatePost(Long postId, PostRequest request, Long userId) {
+        // Post 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 작성자 검증
+        if (!post.getUser().getId().equals(userId)) {
+            throw new CustomException(ErrorCode.POST_NO_PERMISSION);
+        }
+
+        // Post 업데이트
+        post.update(request.title(), request.content());
+
+        // Category 매핑 업데이트
+        List<PostCategory> categories = postCategoryRepository.findAllById(request.categoryIds());
+        if (categories.size() != request.categoryIds().size()) {
+            throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
+        }
+        post.updateCategories(categories);
+
+        // 응답 반환
+        return PostResponse.from(post);
+    }
 }

--- a/src/test/java/com/back/domain/board/service/PostServiceTest.java
+++ b/src/test/java/com/back/domain/board/service/PostServiceTest.java
@@ -66,7 +66,7 @@ class PostServiceTest {
         assertThat(response.content()).isEqualTo("내용");
         assertThat(response.author().nickname()).isEqualTo("작성자");
         assertThat(response.categories()).hasSize(1);
-        assertThat(response.categories().get(0).name()).isEqualTo("공지");
+        assertThat(response.categories().getFirst().name()).isEqualTo("공지");
     }
 
     @Test
@@ -171,5 +171,108 @@ class PostServiceTest {
         assertThatThrownBy(() -> postService.getPost(999L))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.POST_NOT_FOUND.getMessage());
+    }
+
+    // ====================== 게시글 수정 테스트 ======================
+
+    @Test
+    @DisplayName("게시글 수정 성공 - 작성자 본인")
+    void updatePost_success() {
+        // given
+        User user = User.createUser("writer", "writer@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        PostCategory oldCategory = new PostCategory("공지");
+        PostCategory newCategory = new PostCategory("자유");
+        postCategoryRepository.saveAll(List.of(oldCategory, newCategory));
+
+        Post post = new Post(user, "원래 제목", "원래 내용");
+        post.updateCategories(List.of(oldCategory));
+        postRepository.save(post);
+
+        PostRequest request = new PostRequest("수정된 제목", "수정된 내용", List.of(newCategory.getId()));
+
+        // when
+        PostResponse response = postService.updatePost(post.getId(), request, user.getId());
+
+        // then
+        assertThat(response.title()).isEqualTo("수정된 제목");
+        assertThat(response.content()).isEqualTo("수정된 내용");
+        assertThat(response.categories()).hasSize(1);
+        assertThat(response.categories().getFirst().name()).isEqualTo("자유");
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 게시글 없음")
+    void updatePost_fail_postNotFound() {
+        // given
+        User user = User.createUser("writer2", "writer2@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자2", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        PostRequest request = new PostRequest("제목", "내용", List.of());
+
+        // when & then
+        assertThatThrownBy(() -> postService.updatePost(999L, request, user.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.POST_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 작성자 아님")
+    void updatePost_fail_noPermission() {
+        // given: 게시글 작성자
+        User writer = User.createUser("writer3", "writer3@example.com", "encodedPwd");
+        writer.setUserProfile(new UserProfile(writer, "작성자3", null, null, null, 0));
+        writer.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(writer);
+
+        // 다른 사용자
+        User another = User.createUser("other", "other@example.com", "encodedPwd");
+        another.setUserProfile(new UserProfile(another, "다른사람", null, null, null, 0));
+        another.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(another);
+
+        PostCategory category = new PostCategory("공지");
+        postCategoryRepository.save(category);
+
+        Post post = new Post(writer, "원래 제목", "원래 내용");
+        post.updateCategories(List.of(category));
+        postRepository.save(post);
+
+        PostRequest request = new PostRequest("수정된 제목", "수정된 내용", List.of(category.getId()));
+
+        // when & then
+        assertThatThrownBy(() -> postService.updatePost(post.getId(), request, another.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.POST_NO_PERMISSION.getMessage());
+    }
+
+    @Test
+    @DisplayName("게시글 수정 실패 - 존재하지 않는 카테고리 포함")
+    void updatePost_fail_categoryNotFound() {
+        // given
+        User user = User.createUser("writer4", "writer4@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자4", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        PostCategory category = new PostCategory("공지");
+        postCategoryRepository.save(category);
+
+        Post post = new Post(user, "원래 제목", "원래 내용");
+        post.updateCategories(List.of(category));
+        postRepository.save(post);
+
+        // 실제 DB에는 없는 카테고리 ID 전달
+        PostRequest request = new PostRequest("수정된 제목", "수정된 내용", List.of(999L));
+
+        // when & then
+        assertThatThrownBy(() -> postService.updatePost(post.getId(), request, user.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.CATEGORY_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

* 로그인한 사용자가 본인 게시글을 수정하거나 삭제할 수 있는 API를 구현했습니다.
* Controller, Service, Test, Swagger 문서화를 포함합니다.

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->


1. **Controller**

   * `PostController#updatePost`
     * `PUT /api/posts/{postId}`
     * 요청 DTO(`PostRequest`) + 인증 사용자(`CustomUserDetails`)
     * 수정 성공 시 `200 OK` + 수정된 게시글 정보 반환

   * `PostController#deletePost`
     * `DELETE /api/posts/{postId}`
     * 인증 사용자만 접근 가능
     * 삭제 성공 시 `200 OK` + 메시지 반환

2. **Service**

   * `PostService#updatePost`
     * 게시글 조회 (`POST_NOT_FOUND`)
     * 작성자 검증 (`POST_NO_PERMISSION`)
     * 제목/내용/카테고리 업데이트
     * 존재하지 않는 카테고리 포함 시 `CATEGORY_NOT_FOUND`
     * `PostResponse` 반환

   * `PostService#deletePost`
     * 게시글 조회 (`POST_NOT_FOUND`)
     * 작성자 검증 (`POST_NO_PERMISSION`)
     * 게시글 삭제

3. **DTO**

   * `PostRequest`, `PostResponse` 재활용

4. **Test**

   * **서비스 테스트**
     * 수정 성공 → 제목/내용/카테고리 변경 확인
     * 수정 실패 → 게시글 없음, 작성자 아님, 카테고리 없음
     * 삭제 성공 → DB에서 게시글 제거
     * 삭제 실패 → 게시글 없음, 작성자 아님

   * **컨트롤러 테스트 (MockMvc)**
     * 수정 성공 → `200 OK`
     * 수정 실패 → `404 Not Found`, `403 Forbidden`, `400 Bad Request`, `401 Unauthorized`
     * 삭제 성공 → `200 OK`
     * 삭제 실패 → `404 Not Found`, `403 Forbidden`, `401 Unauthorized`

5. **Swagger 문서 (`PostControllerDocs`)**

   * `게시글 수정 API` 문서화
     * 성공/실패 응답 JSON 예시

   * `게시글 삭제 API` 문서화
     * 성공/실패 응답 JSON 예시

   * 에러 케이스:
     * `POST_NOT_FOUND`, `POST_NO_PERMISSION`, `CATEGORY_NOT_FOUND`
     * `COMMON_400`, `AUTH_001~004`, `COMMON_500`

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #131

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
