### PR TITLE
Refactor: 스터디룸 권한에 대한 로직 개선과 DB (#146)

### DIFF
--- a/src/main/java/com/back/domain/studyroom/dto/ChangeRoleRequest.java
+++ b/src/main/java/com/back/domain/studyroom/dto/ChangeRoleRequest.java
@@ -1,0 +1,21 @@
+package com.back.domain.studyroom.dto;
+
+import com.back.domain.studyroom.entity.RoomRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 멤버 역할 변경 요청 DTO
+ * - VISITOR → MEMBER/SUB_HOST/HOST 모두 가능
+ * - HOST로 변경 시 기존 방장은 자동으로 MEMBER로 강등
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangeRoleRequest {
+    
+    @NotNull(message = "역할은 필수입니다")
+    private RoomRole newRole;
+}

--- a/src/main/java/com/back/domain/studyroom/dto/ChangeRoleResponse.java
+++ b/src/main/java/com/back/domain/studyroom/dto/ChangeRoleResponse.java
@@ -1,0 +1,47 @@
+package com.back.domain.studyroom.dto;
+
+import com.back.domain.studyroom.entity.RoomRole;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 역할 변경 응답 DTO
+ */
+@Getter
+@Builder
+public class ChangeRoleResponse {
+    
+    private Long userId;
+    private String nickname;
+    private RoomRole oldRole;
+    private RoomRole newRole;
+    private String message;
+    
+    public static ChangeRoleResponse of(Long userId, String nickname, 
+                                       RoomRole oldRole, RoomRole newRole) {
+        String message = buildMessage(oldRole, newRole);
+        
+        return ChangeRoleResponse.builder()
+                .userId(userId)
+                .nickname(nickname)
+                .oldRole(oldRole)
+                .newRole(newRole)
+                .message(message)
+                .build();
+    }
+    
+    private static String buildMessage(RoomRole oldRole, RoomRole newRole) {
+        if (newRole == RoomRole.HOST) {
+            return "방장으로 임명되었습니다.";
+        } else if (oldRole == RoomRole.HOST) {
+            return "방장 권한이 해제되었습니다.";
+        } else if (newRole == RoomRole.SUB_HOST) {
+            return "부방장으로 승격되었습니다.";
+        } else if (newRole == RoomRole.MEMBER && oldRole == RoomRole.VISITOR) {
+            return "정식 멤버로 승격되었습니다.";
+        } else if (newRole == RoomRole.MEMBER) {
+            return "일반 멤버로 강등되었습니다.";
+        }
+        return "역할이 변경되었습니다.";
+    }
+}

--- a/src/main/java/com/back/domain/studyroom/repository/RoomMemberRepositoryCustom.java
+++ b/src/main/java/com/back/domain/studyroom/repository/RoomMemberRepositoryCustom.java
@@ -65,6 +65,15 @@ public interface RoomMemberRepositoryCustom {
     boolean existsByRoomIdAndUserId(Long roomId, Long userId);
 
     /**
+     * 여러 사용자의 멤버십 일괄 조회 (IN 절)
+     * Redis에서 온라인 사용자 목록을 받아서 DB 멤버십 조회 시 사용
+     * @param roomId 방 ID
+     * @param userIds 사용자 ID 목록
+     * @return 멤버십 목록 (MEMBER 이상만 DB에 있음)
+     */
+    List<RoomMember> findByRoomIdAndUserIdIn(Long roomId, java.util.Set<Long> userIds);
+
+    /**
      * 특정 역할의 멤버 수 조회
      * TODO: Redis 기반으로 변경 예정
      */

--- a/src/main/java/com/back/domain/studyroom/service/RoomRedisService.java
+++ b/src/main/java/com/back/domain/studyroom/service/RoomRedisService.java
@@ -1,0 +1,116 @@
+package com.back.domain.studyroom.service;
+
+import com.back.global.websocket.service.WebSocketSessionManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 방 상태 관리를 위한 Redis 전용 서비스
+ *   방의 온라인 사용자 관리 (입장/퇴장)
+ *   실시간 참가자 수 조회
+ *   온라인 사용자 목록 조회
+ * Redis: 실시간 온라인 상태만 관리 (휘발성 데이터)
+ * DB: 영구 멤버십 + 역할 정보 (MEMBER 이상만 저장)
+ * 역할(Role)은 Redis에 저장하지 않음!
+ *   이유 1: DB가 Single Source of Truth (데이터 일관성)
+ *   이유 2: Redis-DB 동기화 복잡도 제거
+ *   이유 3: 멤버 목록 조회 시 IN 절로 효율적 조회 가능
+ * @see com.back.global.websocket.service.WebSocketSessionManager WebSocket 세션 관리
+ * @see com.back.domain.studyroom.repository.RoomMemberRepository DB 멤버십 조회
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoomRedisService {
+
+    private final WebSocketSessionManager sessionManager;
+
+    // ==================== 방 입장/퇴장 ====================
+
+    /**
+     * 사용자가 방에 입장 (Redis 온라인 상태 업데이트)
+     * - Redis Set에 userId 추가
+     * - 역할(Role)은 DB에서만 관리
+     *
+     * @param userId 사용자 ID
+     * @param roomId 방 ID
+     */
+    public void enterRoom(Long userId, Long roomId) {
+        sessionManager.joinRoom(userId, roomId);
+        log.info("방 입장 완료 (Redis) - 사용자: {}, 방: {}", userId, roomId);
+    }
+
+    /**
+     * 사용자가 방에서 퇴장 (Redis 온라인 상태 업데이트)
+     * - Redis Set에서 userId 제거
+     * - DB 멤버십은 유지됨 (재입장 시 역할 유지)
+     *
+     * @param userId 사용자 ID
+     * @param roomId 방 ID
+     */
+    public void exitRoom(Long userId, Long roomId) {
+        sessionManager.leaveRoom(userId, roomId);
+        log.info("방 퇴장 완료 (Redis) - 사용자: {}, 방: {}", userId, roomId);
+    }
+
+    // ==================== 조회 ====================
+
+    /**
+     * 방의 현재 온라인 사용자 수 조회
+     * - 실시간 참가자 수 (DB currentParticipants와 무관)
+     *
+     * @param roomId 방 ID
+     * @return 온라인 사용자 수
+     */
+    public long getRoomUserCount(Long roomId) {
+        return sessionManager.getRoomOnlineUserCount(roomId);
+    }
+
+    /**
+     * 방의 온라인 사용자 ID 목록 조회
+     * - 멤버 목록 조회 시 이 ID로 DB 조회
+     * - DB에 없는 ID = VISITOR
+     *
+     * @param roomId 방 ID
+     * @return 온라인 사용자 ID Set
+     */
+    public Set<Long> getRoomUsers(Long roomId) {
+        return sessionManager.getOnlineUsersInRoom(roomId);
+    }
+
+    /**
+     * 사용자가 현재 특정 방에 있는지 확인
+     *
+     * @param userId 사용자 ID
+     * @param roomId 방 ID
+     * @return 온라인 여부
+     */
+    public boolean isUserInRoom(Long userId, Long roomId) {
+        return sessionManager.isUserInRoom(userId, roomId);
+    }
+
+    /**
+     * 사용자의 현재 방 ID 조회
+     * 
+     * @param userId 사용자 ID
+     * @return 방 ID (없으면 null)
+     */
+    public Long getCurrentRoomId(Long userId) {
+        return sessionManager.getUserCurrentRoomId(userId);
+    }
+
+    /**
+     * 여러 방의 온라인 사용자 수 일괄 조회 (N+1 방지)
+     * - 방 목록 조회 시 사용
+     * 
+     * @param roomIds 방 ID 목록
+     * @return Map<RoomId, OnlineCount>
+     */
+    public Map<Long, Long> getBulkRoomOnlineUserCounts(java.util.List<Long> roomIds) {
+        return sessionManager.getBulkRoomOnlineUserCounts(roomIds);
+    }
+}

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -32,9 +32,10 @@ public enum ErrorCode {
     NOT_ROOM_MANAGER(HttpStatus.FORBIDDEN, "ROOM_009", "방 관리자 권한이 필요합니다."),
     CANNOT_KICK_HOST(HttpStatus.BAD_REQUEST, "ROOM_010", "방장은 추방할 수 없습니다."),
     CANNOT_CHANGE_HOST_ROLE(HttpStatus.BAD_REQUEST, "ROOM_011", "방장의 권한은 변경할 수 없습니다."),
-    CHAT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "ROOM_012", "채팅 삭제 권한이 없습니다. 방장 또는 부방장만 가능합니다."),
-    INVALID_DELETE_CONFIRMATION(HttpStatus.BAD_REQUEST, "ROOM_013", "삭제 확인 메시지가 일치하지 않습니다."),
-    CHAT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ROOM_014", "채팅 삭제 중 오류가 발생했습니다."),
+    CANNOT_CHANGE_OWN_ROLE(HttpStatus.BAD_REQUEST, "ROOM_012", "자신의 역할은 변경할 수 없습니다."),
+    CHAT_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "ROOM_013", "채팅 삭제 권한이 없습니다. 방장 또는 부방장만 가능합니다."),
+    INVALID_DELETE_CONFIRMATION(HttpStatus.BAD_REQUEST, "ROOM_014", "삭제 확인 메시지가 일치하지 않습니다."),
+    CHAT_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ROOM_015", "채팅 삭제 중 오류가 발생했습니다."),
 
     // ======================== 스터디 플래너 관련 ========================
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "PLAN_001", "존재하지 않는 학습 계획입니다."),


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

VISITOR(멤버 보다 낮은 참여자) -> Redis에만 저장하고 DB에 저장은 MEMBER 등급 이상부터.
성능개선 : 
- 100명이 난대 없이 들어왔다 나갓다 해도 DB INSERT절이 발생 안함
- 조회 N+1 문제 해결 : IN 절로 일괄 조회 하도록

---
## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 권한에 대한 로직 수정

- VISITOR DB 저장 제거
- 통합 역할 변경 API 추가 - PUT /api/rooms/{roomId}/members/{userId}/role
  - 모든 유저에 대해서 방장이 권한 변경 가능,
  - 방장이 다른 사람에게 방장을 부여 시 자동으로 MEMBER로 강등
  - 본인 역할 변경 불가
- 방장이 퇴장 해도 방 유지 되도록 변경 (참여자 0명이어도, 방장 재입장 시 방장 권한 유지, 방 종료는 방장만 명시적으로 가능)
- 해당 로직 변경에 대한 에러코드 작성

---

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #146 

---

## 📝 참고 사항


테스트 코드 작성 예정입니다.
로컬에서 테스트 완료했습니다.

---

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화
