### PR TITLE
Feat: 댓글 조회 API 구현 (#162)

### DIFF
--- a/src/main/java/com/back/domain/board/controller/CommentController.java
+++ b/src/main/java/com/back/domain/board/controller/CommentController.java
@@ -1,12 +1,17 @@
 package com.back.domain.board.controller;
 
+import com.back.domain.board.dto.CommentListResponse;
 import com.back.domain.board.dto.CommentRequest;
 import com.back.domain.board.dto.CommentResponse;
+import com.back.domain.board.dto.PageResponse;
 import com.back.domain.board.service.CommentService;
 import com.back.global.common.dto.RsData;
 import com.back.global.security.user.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,6 +35,21 @@ public class CommentController implements CommentControllerDocs {
                 .status(HttpStatus.CREATED)
                 .body(RsData.success(
                         "댓글이 생성되었습니다.",
+                        response
+                ));
+    }
+
+    // 댓글 다건 조회
+    @GetMapping
+    public ResponseEntity<RsData<PageResponse<CommentListResponse>>> getComments(
+            @PathVariable Long postId,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        PageResponse<CommentListResponse> response = commentService.getComments(postId, pageable);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success(
+                        "댓글 목록이 조회되었습니다.",
                         response
                 ));
     }
@@ -62,8 +82,8 @@ public class CommentController implements CommentControllerDocs {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(RsData.success(
-                   "댓글이 삭제되었습니다.",
-                   null
+                        "댓글이 삭제되었습니다.",
+                        null
                 ));
     }
 }

--- a/src/main/java/com/back/domain/board/controller/CommentControllerDocs.java
+++ b/src/main/java/com/back/domain/board/controller/CommentControllerDocs.java
@@ -1,7 +1,9 @@
 package com.back.domain.board.controller;
 
+import com.back.domain.board.dto.CommentListResponse;
 import com.back.domain.board.dto.CommentRequest;
 import com.back.domain.board.dto.CommentResponse;
+import com.back.domain.board.dto.PageResponse;
 import com.back.global.common.dto.RsData;
 import com.back.global.security.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,6 +12,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -140,6 +143,115 @@ public interface CommentControllerDocs {
             @PathVariable Long postId,
             @RequestBody CommentRequest request,
             @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "댓글 목록 조회",
+            description = "특정 게시글에 달린 댓글 목록을 조회합니다. " +
+                    "부모 댓글 기준으로 페이징되며, 각 댓글의 대댓글(children) 목록이 함께 포함됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "댓글 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "댓글 목록이 조회되었습니다.",
+                                      "data": {
+                                        "content": [
+                                          {
+                                            "commentId": 1,
+                                            "postId": 101,
+                                            "parentId": null,
+                                            "author": {
+                                              "id": 5,
+                                              "nickname": "홍길동"
+                                            },
+                                            "content": "부모 댓글",
+                                            "likeCount": 2,
+                                            "createdAt": "2025-09-22T11:30:00",
+                                            "updatedAt": "2025-09-22T11:30:00",
+                                            "children": [
+                                              {
+                                                "commentId": 2,
+                                                "postId": 101,
+                                                "parentId": 1,
+                                                "author": {
+                                                  "id": 5,
+                                                  "nickname": "홍길동"
+                                                },
+                                                "content": "자식 댓글",
+                                                "likeCount": 0,
+                                                "createdAt": "2025-09-22T11:35:00",
+                                                "updatedAt": "2025-09-22T11:35:00",
+                                                "children": []
+                                              }
+                                            ]
+                                          }
+                                        ],
+                                        "pageNumber": 0,
+                                        "pageSize": 10,
+                                        "totalElements": 1,
+                                        "totalPages": 1,
+                                        "last": true
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (파라미터 오류)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_400",
+                                      "message": "잘못된 요청입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 게시글",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "POST_001",
+                                      "message": "존재하지 않는 게시글입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<PageResponse<CommentListResponse>>> getComments(
+            @PathVariable Long postId,
+            Pageable pageable
     );
 
     @Operation(

--- a/src/main/java/com/back/domain/board/dto/AuthorResponse.java
+++ b/src/main/java/com/back/domain/board/dto/AuthorResponse.java
@@ -1,6 +1,7 @@
 package com.back.domain.board.dto;
 
 import com.back.domain.user.entity.User;
+import com.querydsl.core.annotations.QueryProjection;
 
 /**
  * 작성자 응답 DTO
@@ -12,6 +13,9 @@ public record AuthorResponse(
         Long id,
         String nickname
 ) {
+    @QueryProjection
+    public AuthorResponse {}
+
     public static AuthorResponse from(User user) {
         return new AuthorResponse(
                 user.getId(),

--- a/src/main/java/com/back/domain/board/dto/CommentListResponse.java
+++ b/src/main/java/com/back/domain/board/dto/CommentListResponse.java
@@ -1,0 +1,50 @@
+package com.back.domain.board.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 댓글 목록 응답 DTO
+ */
+@Getter
+public class CommentListResponse {
+    private final Long commentId;
+    private final Long postId;
+    private final Long parentId;
+    private final AuthorResponse author;
+    private final String content;
+
+    @Setter
+    private long likeCount;
+
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    @Setter
+    private List<CommentListResponse> children;
+
+    @QueryProjection
+    public CommentListResponse(Long commentId,
+                               Long postId,
+                               Long parentId,
+                               AuthorResponse author,
+                               String content,
+                               long likeCount,
+                               LocalDateTime createdAt,
+                               LocalDateTime updatedAt,
+                               List<CommentListResponse> children) {
+        this.commentId = commentId;
+        this.postId = postId;
+        this.parentId = parentId;
+        this.author = author;
+        this.content = content;
+        this.likeCount = likeCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.children = children;
+    }
+}

--- a/src/main/java/com/back/domain/board/entity/Comment.java
+++ b/src/main/java/com/back/domain/board/entity/Comment.java
@@ -41,6 +41,13 @@ public class Comment extends BaseEntity {
         this.user = user;
         this.content = content;
     }
+
+    public Comment(Post post, User user, String content, Comment parent) {
+        this.post = post;
+        this.user = user;
+        this.content = content;
+        this.parent = parent;
+    }
     
     // -------------------- 비즈니스 메서드 --------------------
     // 댓글 업데이트

--- a/src/main/java/com/back/domain/board/repository/CommentRepository.java
+++ b/src/main/java/com/back/domain/board/repository/CommentRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentRepositoryCustom {
 }

--- a/src/main/java/com/back/domain/board/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/back/domain/board/repository/CommentRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.back.domain.board.repository;
+
+import com.back.domain.board.dto.CommentListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentRepositoryCustom {
+    Page<CommentListResponse> getCommentsByPostId(Long postId, Pageable pageable);
+}

--- a/src/main/java/com/back/domain/board/repository/CommentRepositoryImpl.java
+++ b/src/main/java/com/back/domain/board/repository/CommentRepositoryImpl.java
@@ -1,0 +1,158 @@
+package com.back.domain.board.repository;
+
+import com.back.domain.board.dto.CommentListResponse;
+import com.back.domain.board.dto.QAuthorResponse;
+import com.back.domain.board.dto.QCommentListResponse;
+import com.back.domain.board.entity.Comment;
+import com.back.domain.board.entity.QComment;
+import com.back.domain.board.entity.QCommentLike;
+import com.back.domain.user.entity.QUser;
+import com.back.domain.user.entity.QUserProfile;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CommentListResponse> getCommentsByPostId(Long postId, Pageable pageable) {
+        QComment comment = QComment.comment;
+        QCommentLike commentLike = QCommentLike.commentLike;
+
+        // 정렬 조건
+        List<OrderSpecifier<?>> orders = buildOrderSpecifiers(pageable, comment, commentLike);
+
+        // 부모 댓글 조회
+        List<CommentListResponse> parents = fetchComments(
+                comment.post.id.eq(postId).and(comment.parent.isNull()),
+                orders,
+                pageable.getOffset(),
+                pageable.getPageSize()
+        );
+
+        if (parents.isEmpty()) {
+            return new PageImpl<>(parents, pageable, 0);
+        }
+
+        // 부모 id 수집
+        List<Long> parentIds = parents.stream()
+                .map(CommentListResponse::getCommentId)
+                .toList();
+
+        // 자식 댓글 조회
+        List<CommentListResponse> children = fetchComments(
+                comment.parent.id.in(parentIds),
+                List.of(comment.createdAt.asc()),
+                null,
+                null
+        );
+
+        // 부모 + 자식 id 합쳐서 likeCount 한 번에 조회
+        List<Long> allIds = new ArrayList<>(parentIds);
+        allIds.addAll(children.stream().map(CommentListResponse::getCommentId).toList());
+
+        Map<Long, Long> likeCountMap = queryFactory
+                .select(commentLike.comment.id, commentLike.count())
+                .from(commentLike)
+                .where(commentLike.comment.id.in(allIds))
+                .groupBy(commentLike.comment.id)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(commentLike.comment.id),
+                        tuple -> tuple.get(commentLike.count())
+                ));
+
+        // likeCount 세팅
+        parents.forEach(p -> p.setLikeCount(likeCountMap.getOrDefault(p.getCommentId(), 0L)));
+        children.forEach(c -> c.setLikeCount(likeCountMap.getOrDefault(c.getCommentId(), 0L)));
+
+        // parentId → children 매핑
+        Map<Long, List<CommentListResponse>> childMap = children.stream()
+                .collect(Collectors.groupingBy(CommentListResponse::getParentId));
+
+        parents.forEach(p ->
+                p.setChildren(childMap.getOrDefault(p.getCommentId(), List.of()))
+        );
+
+        // 총 개수 (부모 댓글만 카운트)
+        Long total = queryFactory
+                .select(comment.count())
+                .from(comment)
+                .where(comment.post.id.eq(postId).and(comment.parent.isNull()))
+                .fetchOne();
+
+        return new PageImpl<>(parents, pageable, total != null ? total : 0L);
+    }
+
+    /**
+     * 공통 댓글 조회 메서드 (부모/자식 공통)
+     */
+    private List<CommentListResponse> fetchComments(
+            BooleanExpression condition,
+            List<OrderSpecifier<?>> orders,
+            Long offset,
+            Integer limit
+    ) {
+        QComment comment = QComment.comment;
+        QUser user = QUser.user;
+        QUserProfile profile = QUserProfile.userProfile;
+
+        var query = queryFactory
+                .select(new QCommentListResponse(
+                        comment.id,
+                        comment.post.id,
+                        comment.parent.id,
+                        new QAuthorResponse(user.id, profile.nickname),
+                        comment.content,
+                        Expressions.constant(0L), // likeCount placeholder
+                        comment.createdAt,
+                        comment.updatedAt,
+                        Expressions.constant(Collections.emptyList())
+                ))
+                .from(comment)
+                .leftJoin(comment.user, user)
+                .leftJoin(user.userProfile, profile)
+                .where(condition)
+                .orderBy(orders.toArray(new OrderSpecifier[0]));
+
+        if (offset != null && limit != null) {
+            query.offset(offset).limit(limit);
+        }
+
+        return query.fetch();
+    }
+
+    /**
+     * 정렬 조건 처리
+     */
+    private List<OrderSpecifier<?>> buildOrderSpecifiers(Pageable pageable, QComment comment, QCommentLike commentLike) {
+        PathBuilder<Comment> entityPath = new PathBuilder<>(Comment.class, comment.getMetadata());
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        for (Sort.Order order : pageable.getSort()) {
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            String prop = order.getProperty();
+
+            switch (prop) {
+                case "likeCount" -> orders.add(new OrderSpecifier<>(direction, commentLike.id.countDistinct()));
+                default -> orders.add(new OrderSpecifier<>(direction,
+                        entityPath.getComparable(prop, Comparable.class)));
+            }
+        }
+        return orders;
+    }
+}

--- a/src/main/java/com/back/domain/board/service/CommentService.java
+++ b/src/main/java/com/back/domain/board/service/CommentService.java
@@ -1,7 +1,9 @@
 package com.back.domain.board.service;
 
+import com.back.domain.board.dto.CommentListResponse;
 import com.back.domain.board.dto.CommentRequest;
 import com.back.domain.board.dto.CommentResponse;
+import com.back.domain.board.dto.PageResponse;
 import com.back.domain.board.entity.Comment;
 import com.back.domain.board.entity.Post;
 import com.back.domain.board.repository.CommentRepository;
@@ -11,6 +13,8 @@ import com.back.domain.user.repository.UserRepository;
 import com.back.global.exception.CustomException;
 import com.back.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,6 +48,24 @@ public class CommentService {
         // Comment 저장 및 응답 반환
         commentRepository.save(comment);
         return CommentResponse.from(comment);
+    }
+
+    /**
+     * 댓글 다건 조회 서비스
+     * 1. Post 조회
+     * 2. 해당 Post의 댓글 전체 조회 (대댓글 포함, 페이징)
+     * 3. PageResponse 반환
+     */
+    @Transactional(readOnly = true)
+    public PageResponse<CommentListResponse> getComments(Long postId, Pageable pageable) {
+        // Post 조회
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 댓글 목록 조회
+        Page<CommentListResponse> comments = commentRepository.getCommentsByPostId(postId, pageable);
+
+        return PageResponse.from(comments);
     }
 
     /**


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

* 특정 게시글에 등록된 댓글 목록을 조회할 수 있는 API를 구현했습니다.
* 부모 댓글 기준으로 페이징 처리하며, 각 부모 댓글에는 자식 댓글(children)이 계층 구조로 포함됩니다.

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 1. Controller

* `GET /api/posts/{postId}/comments` → 댓글 다건 조회 엔드포인트 구현

### 2. Service

* `CommentService#getComments`
  * 게시글 존재 여부 검증
  * `CommentRepositoryCustom`을 통해 댓글/대댓글 조회
  * `PageResponse<CommentListResponse>` 형태로 반환

### 3. Repository

* `CommentRepositoryImpl#getCommentsByPostId`
  * QueryDSL 기반 구현
  * 부모 댓글/자식 댓글 각각 조회
  * likeCount 집계 한 번에 처리
  * 부모-자식 매핑 후 Page 객체 반환

### 4. DTO

* `CommentListResponse`
  * `commentId, postId, parentId, author, content, likeCount, createdAt, updatedAt, children` 필드 포함
  * `@QueryProjection` 사용

### 5. Swagger

* `CommentControllerDocs`에 댓글 조회 API 문서 추가
  * 성공/실패/예외 응답 예시 작성

### 6. Test

* **Service Test**
  * 댓글 조회 성공 (부모+자식 구조 확인)
  * 게시글 없음 예외 검증 (`POST_001`)

* **Controller Test**
  * 성공 시 → 댓글 목록 + 대댓글 구조 반환 확인
  * 실패 시 → 게시글 없음 (`404`), 잘못된 파라미터 (`400`) 검증

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #162

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 추후 최적화 및 가독성 향상을 위한 리팩토링 예정

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
