### PR TITLE
Feat: 대댓글 생성 API 구현 (#177)

### DIFF
--- a/src/main/java/com/back/domain/board/comment/controller/CommentController.java
+++ b/src/main/java/com/back/domain/board/comment/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.back.domain.board.comment.controller;
 import com.back.domain.board.comment.dto.CommentListResponse;
 import com.back.domain.board.comment.dto.CommentRequest;
 import com.back.domain.board.comment.dto.CommentResponse;
+import com.back.domain.board.comment.dto.ReplyResponse;
 import com.back.domain.board.common.dto.PageResponse;
 import com.back.domain.board.comment.service.CommentService;
 import com.back.global.common.dto.RsData;
@@ -84,6 +85,23 @@ public class CommentController implements CommentControllerDocs {
                 .body(RsData.success(
                         "댓글이 삭제되었습니다.",
                         null
+                ));
+    }
+
+    // 대댓글 생성
+    @PostMapping("/{commentId}/replies")
+    public ResponseEntity<RsData<ReplyResponse>> createReply(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestBody @Valid CommentRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        ReplyResponse response = commentService.createReply(postId, commentId, request, user.getUserId());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(RsData.success(
+                        "대댓글이 생성되었습니다.",
+                        response
                 ));
     }
 }

--- a/src/main/java/com/back/domain/board/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/back/domain/board/comment/controller/CommentControllerDocs.java
@@ -3,6 +3,7 @@ package com.back.domain.board.comment.controller;
 import com.back.domain.board.comment.dto.CommentListResponse;
 import com.back.domain.board.comment.dto.CommentRequest;
 import com.back.domain.board.comment.dto.CommentResponse;
+import com.back.domain.board.comment.dto.ReplyResponse;
 import com.back.domain.board.common.dto.PageResponse;
 import com.back.global.common.dto.RsData;
 import com.back.global.security.user.CustomUserDetails;
@@ -507,6 +508,159 @@ public interface CommentControllerDocs {
     ResponseEntity<RsData<Void>> deleteComment(
             @PathVariable Long postId,
             @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "대댓글 생성",
+            description = "로그인한 사용자가 특정 게시글의 댓글에 대댓글을 작성합니다. (대댓글은 1단계까지만 허용됩니다.)"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "대댓글 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "대댓글이 생성되었습니다.",
+                                      "data": {
+                                        "replyId": 45,
+                                        "postId": 101,
+                                        "parentId": 25,
+                                        "author": {
+                                          "id": 7,
+                                          "nickname": "이몽룡"
+                                        },
+                                        "content": "저도 동의합니다!",
+                                        "createdAt": "2025-09-22T13:30:00",
+                                        "updatedAt": "2025-09-22T13:30:00"
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 또는 depth 제한 초과",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "필드 누락", value = """
+                                            {
+                                              "success": false,
+                                              "code": "COMMON_400",
+                                              "message": "잘못된 요청입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "부모 댓글 불일치", value = """
+                                            {
+                                              "success": false,
+                                              "code": "COMMENT_003",
+                                              "message": "부모 댓글이 해당 게시글에 속하지 않습니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "depth 초과", value = """
+                                            {
+                                              "success": false,
+                                              "code": "COMMENT_004",
+                                              "message": "대댓글은 한 단계까지만 작성할 수 있습니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (토큰 없음/잘못됨/만료)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "토큰 없음", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_001",
+                                              "message": "인증이 필요합니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "잘못된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_002",
+                                              "message": "유효하지 않은 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "만료된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_004",
+                                              "message": "만료된 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 사용자 / 게시글 / 댓글",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "존재하지 않는 사용자", value = """
+                                            {
+                                              "success": false,
+                                              "code": "USER_001",
+                                              "message": "존재하지 않는 사용자입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "존재하지 않는 게시글", value = """
+                                            {
+                                              "success": false,
+                                              "code": "POST_001",
+                                              "message": "존재하지 않는 게시글입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "존재하지 않는 댓글", value = """
+                                            {
+                                              "success": false,
+                                              "code": "COMMENT_001",
+                                              "message": "존재하지 않는 댓글입니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<ReplyResponse>> createReply(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestBody CommentRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     );
 }

--- a/src/main/java/com/back/domain/board/comment/dto/ReplyResponse.java
+++ b/src/main/java/com/back/domain/board/comment/dto/ReplyResponse.java
@@ -1,0 +1,39 @@
+package com.back.domain.board.comment.dto;
+
+import com.back.domain.board.comment.entity.Comment;
+import com.back.domain.board.common.dto.AuthorResponse;
+
+import java.time.LocalDateTime;
+
+/**
+ * 대댓글 응답 DTO
+ *
+ * @param commentId 댓글 Id
+ * @param postId    게시글 Id
+ * @param parentId  부모 댓글 Id
+ * @param author    작성자 정보
+ * @param content   댓글 내용
+ * @param createdAt 댓글 생성 일시
+ * @param updatedAt 댓글 수정 일시
+ */
+public record ReplyResponse(
+        Long commentId,
+        Long postId,
+        Long parentId,
+        AuthorResponse author,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ReplyResponse from(Comment comment) {
+        return new ReplyResponse(
+                comment.getId(),
+                comment.getPost().getId(),
+                comment.getParent().getId(),
+                AuthorResponse.from(comment.getUser()),
+                comment.getContent(),
+                comment.getCreatedAt(),
+                comment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -88,6 +88,8 @@ public enum ErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_003", "존재하지 않는 카테고리입니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "존재하지 않는 댓글입니다."),
     COMMENT_NO_PERMISSION(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글 작성자만 수정/삭제할 수 있습니다."),
+    COMMENT_PARENT_MISMATCH(HttpStatus.BAD_REQUEST, "COMMENT_003", "부모 댓글이 해당 게시글에 속하지 않습니다."),
+    COMMENT_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "COMMENT_004", "대댓글은 한 단계까지만 작성할 수 있습니다."),
 
     // ======================== 공통 에러 ========================
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),

--- a/src/test/java/com/back/domain/board/controller/CommentControllerTest.java
+++ b/src/test/java/com/back/domain/board/controller/CommentControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -576,6 +577,249 @@ class CommentControllerTest {
 
         // when & then
         mvc.perform(delete("/api/posts/{postId}/comments/{commentId}", post.getId(), comment.getId()))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_001"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+    // ====================== 대댓글 생성 테스트 ======================
+
+    @Test
+    @DisplayName("대댓글 생성 성공 → 201 Created")
+    void createReply_success() throws Exception {
+        // given: 유저 + 게시글 + 부모 댓글
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, LocalDate.of(2000, 1, 1), 1000));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "첫 글", "내용");
+        postRepository.save(post);
+
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        String accessToken = generateAccessToken(user);
+
+        CommentRequest request = new CommentRequest("저도 동의합니다!");
+
+        // when
+        ResultActions resultActions = mvc.perform(
+                post("/api/posts/{postId}/comments/{commentId}/replies", post.getId(), parent.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        ).andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("SUCCESS_200"))
+                .andExpect(jsonPath("$.data.content").value("저도 동의합니다!"))
+                .andExpect(jsonPath("$.data.author.nickname").value("이몽룡"))
+                .andExpect(jsonPath("$.data.postId").value(post.getId()))
+                .andExpect(jsonPath("$.data.parentId").value(parent.getId()));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 존재하지 않는 사용자 → 404 Not Found")
+    void createReply_userNotFound() throws Exception {
+        // given: 게시글 + 부모 댓글
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        // DB에 없는 userId로 JWT 발급
+        String fakeToken = testJwtTokenProvider.createAccessToken(999L, "ghost@example.com", "USER");
+
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when & then
+        mvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", post.getId(), parent.getId())
+                        .header("Authorization", "Bearer " + fakeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_001"))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 존재하지 않는 게시글 → 404 Not Found")
+    void createReply_postNotFound() throws Exception {
+        // given
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        String accessToken = generateAccessToken(user);
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when & then
+        mvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", 999L, parent.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("POST_001"))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 게시글입니다."));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 존재하지 않는 부모 댓글 → 404 Not Found")
+    void createReply_commentNotFound() throws Exception {
+        // given
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        String accessToken = generateAccessToken(user);
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when & then
+        mvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", post.getId(), 999L)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("COMMENT_001"))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 댓글입니다."));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 부모 댓글이 다른 게시글에 속함 → 400 Bad Request")
+    void createReply_parentMismatch() throws Exception {
+        // given
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post1 = new Post(user, "게시글1", "내용1");
+        Post post2 = new Post(user, "게시글2", "내용2");
+        postRepository.saveAll(List.of(post1, post2));
+
+        Comment parent = new Comment(post1, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        String accessToken = generateAccessToken(user);
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when & then
+        mvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", post2.getId(), parent.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMENT_003"))
+                .andExpect(jsonPath("$.message").value("부모 댓글이 해당 게시글에 속하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - depth 제한 초과(부모가 이미 대댓글) → 400 Bad Request")
+    void createReply_depthExceeded() throws Exception {
+        // given
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        Comment child = new Comment(post, user, "대댓글1", parent);
+        commentRepository.saveAll(List.of(parent, child));
+
+        String accessToken = generateAccessToken(user);
+        CommentRequest request = new CommentRequest("대댓글2");
+
+        // when & then
+        mvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", post.getId(), child.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMENT_004"))
+                .andExpect(jsonPath("$.message").value("대댓글은 한 단계까지만 작성할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 필드 누락(content 없음) → 400 Bad Request")
+    void createReply_badRequest() throws Exception {
+        // given
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        String accessToken = generateAccessToken(user);
+
+        String invalidJson = "{}";
+
+        // when & then
+        mvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", post.getId(), parent.getId())
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidJson))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 토큰 없음 → 401 Unauthorized")
+    void createReply_noToken() throws Exception {
+        // given
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "이몽룡", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when & then
+        mvc.perform(post("/api/posts/{postId}/comments/{commentId}/replies", post.getId(), parent.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AUTH_001"))

--- a/src/test/java/com/back/domain/board/service/CommentServiceTest.java
+++ b/src/test/java/com/back/domain/board/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package com.back.domain.board.service;
 import com.back.domain.board.comment.dto.CommentListResponse;
 import com.back.domain.board.comment.dto.CommentRequest;
 import com.back.domain.board.comment.dto.CommentResponse;
+import com.back.domain.board.comment.dto.ReplyResponse;
 import com.back.domain.board.comment.service.CommentService;
 import com.back.domain.board.common.dto.PageResponse;
 import com.back.domain.board.comment.entity.Comment;
@@ -24,6 +25,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -343,5 +346,103 @@ class CommentServiceTest {
                 commentService.deleteComment(post.getId(), comment.getId(), other.getId())
         ).isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.COMMENT_NO_PERMISSION.getMessage());
+    }
+
+    // ====================== 대댓글 생성 테스트 ======================
+
+    @Test
+    @DisplayName("대댓글 생성 성공")
+    void createReply_success() {
+        // given: 유저 + 게시글 + 부모 댓글 저장
+        User user = User.createUser("writer", "writer@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when
+        ReplyResponse response = commentService.createReply(post.getId(), parent.getId(), request, user.getId());
+
+        // then
+        assertThat(response.content()).isEqualTo("대댓글 내용");
+        assertThat(response.author().nickname()).isEqualTo("작성자");
+        assertThat(response.parentId()).isEqualTo(parent.getId());
+        assertThat(response.postId()).isEqualTo(post.getId());
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 부모 댓글이 다른 게시글에 속함")
+    void createReply_fail_parentMismatch() {
+        // given
+        User user = User.createUser("writer", "writer@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post1 = new Post(user, "게시글1", "내용1");
+        Post post2 = new Post(user, "게시글2", "내용2");
+        postRepository.saveAll(List.of(post1, post2));
+
+        Comment parent = new Comment(post1, user, "부모 댓글", null);
+        commentRepository.save(parent);
+
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when & then
+        assertThatThrownBy(() -> commentService.createReply(post2.getId(), parent.getId(), request, user.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.COMMENT_PARENT_MISMATCH.getMessage());
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 부모 댓글이 이미 대댓글(depth 초과)")
+    void createReply_fail_depthExceeded() {
+        // given
+        User user = User.createUser("writer", "writer@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        // 부모 댓글 + 그 부모의 대댓글까지 생성
+        Comment parent = new Comment(post, user, "부모 댓글", null);
+        Comment child = new Comment(post, user, "대댓글1", parent);
+        commentRepository.saveAll(List.of(parent, child));
+
+        CommentRequest request = new CommentRequest("대댓글2 내용");
+
+        // when & then
+        assertThatThrownBy(() -> commentService.createReply(post.getId(), child.getId(), request, user.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.COMMENT_DEPTH_EXCEEDED.getMessage());
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 실패 - 존재하지 않는 부모 댓글")
+    void createReply_fail_commentNotFound() {
+        // given
+        User user = User.createUser("writer", "writer@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        Post post = new Post(user, "제목", "내용");
+        postRepository.save(post);
+
+        CommentRequest request = new CommentRequest("대댓글 내용");
+
+        // when & then
+        assertThatThrownBy(() -> commentService.createReply(post.getId(), 999L, request, user.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.COMMENT_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

* 게시글의 댓글에 대댓글(1 depth)을 작성할 수 있는 기능을 추가했습니다.
* 서비스, 컨트롤러, 테스트, Swagger 문서까지 통합 구현했습니다.

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 1. 기능 구현

* **`POST /api/posts/{postId}/comments/{commentId}/replies`**
  * 로그인한 사용자가 특정 게시글의 댓글에 대댓글을 작성할 수 있도록 구현
  * 대댓글은 1단계까지만 허용 (대댓글의 대댓글 작성 불가)

* `CommentService#createReply()`
  * 사용자, 게시글, 부모 댓글 조회
  * 부모 댓글의 게시글 일치 및 depth 검증 로직 추가
  * 검증 통과 시 `Comment` 엔티티 생성 후 저장

### 2. DTO 추가

* `ReplyResponse`
  * `commentId`, `postId`, `parentId`, `author`, `content`, `createdAt`, `updatedAt` 포함
  * `ReplyResponse.from(Comment comment)` 팩토리 메서드 추가

### 3. 예외 코드 추가

- COMMENT_PARENT_MISMATCH: 부모 댓글이 해당 게시글에 속하지 않습니다.
- COMMENT_DEPTH_EXCEEDED: 대댓글은 한 단계까지만 작성할 수 있습니다.

### 4. 테스트 코드 작성

#### Service 테스트 (`CommentServiceTest`)
- 대댓글 생성 성공 및 예외 케이스 테스트
- 대댓글 수정 성공 (updateComment)
- 대댓글 삭제 성공 (deleteComment)

#### Controller 테스트 (`CommentControllerTest`)
- 대댓글 생성 성공/실패 케이스 테스트
- 기존 댓글 수정/삭제 API를 통한 대댓글 수정·삭제 테스트 추가

### 5. Swagger 문서 작성 (`CommentControllerDocs`)

* 대댓글 생성 API 명세 추가
* 성공 및 예외 응답 예시 포함 (`201`, `400`, `401`, `404`, `500`)

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #177

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 대댓글 수정/삭제는 기존 댓글 수정/삭제 API를 통해 가능합니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
