### PR TITLE
Test: 알림 시스템 기본 인프라 테스트 (#155)

### DIFF
--- a/src/main/java/com/back/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/back/domain/notification/controller/NotificationController.java
@@ -46,36 +46,58 @@ public class NotificationController {
 
         Notification notification = switch (request.targetType()) {
             case "USER" -> {
-                User targetUser = userRepository.findById(request.targetId())
+                // 수신자 조회
+                User receiver = userRepository.findById(request.targetId())
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                // 발신자 조회
+                User actor = userRepository.findById(request.actorId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
                 yield notificationService.createPersonalNotification(
-                        targetUser,
+                        receiver,
+                        actor,
                         request.title(),
                         request.message(),
                         request.redirectUrl()
                 );
             }
             case "ROOM" -> {
+                // 스터디룸 조회
                 Room room = roomRepository.findById(request.targetId())
                         .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+
+                // 발신자 조회
+                User actor = userRepository.findById(request.actorId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
                 yield notificationService.createRoomNotification(
                         room,
+                        actor,
                         request.title(),
                         request.message(),
                         request.redirectUrl()
                 );
             }
             case "COMMUNITY" -> {
-                User targetUser = userRepository.findById(request.targetId())
+                // 수신자 조회 (리뷰/게시글 작성자)
+                User receiver = userRepository.findById(request.targetId())
                         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                // 발신자 조회 (댓글/좋아요 작성자)
+                User actor = userRepository.findById(request.actorId())
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
                 yield notificationService.createCommunityNotification(
-                        targetUser,
+                        receiver,
+                        actor,
                         request.title(),
                         request.message(),
                         request.redirectUrl()
                 );
             }
             case "SYSTEM" -> {
+                // 시스템 알림은 발신자 없음
                 yield notificationService.createSystemNotification(
                         request.title(),
                         request.message(),

--- a/src/main/java/com/back/domain/notification/dto/ActorDto.java
+++ b/src/main/java/com/back/domain/notification/dto/ActorDto.java
@@ -1,0 +1,18 @@
+package com.back.domain.notification.dto;
+
+import com.back.domain.user.entity.User;
+
+public record ActorDto(
+        Long userId,
+        String username,
+        String profileImageUrl
+) {
+    public static ActorDto from(User user) {
+        if (user == null) return null;
+        return new ActorDto(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/notification/dto/NotificationCreateRequest.java
+++ b/src/main/java/com/back/domain/notification/dto/NotificationCreateRequest.java
@@ -1,13 +1,10 @@
 package com.back.domain.notification.dto;
 
 public record NotificationCreateRequest(
-        String targetType,      // USER, ROOM, SYSTEM
-        Long targetId,          // nullable (SYSTEM일 때 null)
+        String targetType,
+        Long targetId,
+        Long actorId,
         String title,
         String message,
-        String notificationType, // STUDY_REMINDER, ROOM_JOIN 등
-        String redirectUrl,      // targetUrl
-        String scheduleType,     // ONE_TIME (향후 확장용)
-        String scheduledAt       // 예약 시간 (향후 확장용)
-) {
-}
+        String redirectUrl
+) {}

--- a/src/main/java/com/back/domain/notification/dto/NotificationItemDto.java
+++ b/src/main/java/com/back/domain/notification/dto/NotificationItemDto.java
@@ -15,6 +15,7 @@ public record NotificationItemDto(
         NotificationType notificationType,
         String targetUrl,
         boolean isRead,
+        ActorDto actor,
         LocalDateTime createdAt
 ) {
     public static NotificationItemDto from(Notification notification, boolean isRead) {
@@ -25,6 +26,7 @@ public record NotificationItemDto(
                 notification.getType(),
                 notification.getTargetUrl(),
                 isRead,
+                ActorDto.from(notification.getActor()),
                 notification.getCreatedAt()
         );
     }

--- a/src/main/java/com/back/domain/notification/dto/NotificationListResponse.java
+++ b/src/main/java/com/back/domain/notification/dto/NotificationListResponse.java
@@ -15,7 +15,6 @@ public record NotificationListResponse(
         long unreadCount
 ) {
 
-    // 페이지 정보 DTO
     public record PageableDto(
             int page,
             int size,

--- a/src/main/java/com/back/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/back/domain/notification/dto/NotificationResponse.java
@@ -6,7 +6,7 @@ import com.back.domain.notification.entity.NotificationType;
 import java.time.LocalDateTime;
 
 /**
- * 알림 응답 DTO
+ * 알림 상세 응답 DTO
  */
 public record NotificationResponse(
         Long notificationId,
@@ -15,6 +15,7 @@ public record NotificationResponse(
         NotificationType notificationType,
         String targetUrl,
         boolean isRead,
+        ActorDto actor,
         LocalDateTime createdAt,
         LocalDateTime readAt
 ) {
@@ -25,9 +26,10 @@ public record NotificationResponse(
                 notification.getContent(),
                 notification.getType(),
                 notification.getTargetUrl(),
-                false, // 읽음 여부는 NotificationListResponse에서 처리
+                false,
+                ActorDto.from(notification.getActor()),
                 notification.getCreatedAt(),
-                null   // readAt은 NotificationRead에서 가져와야 함
+                null
         );
     }
 
@@ -39,6 +41,7 @@ public record NotificationResponse(
                 notification.getType(),
                 notification.getTargetUrl(),
                 isRead,
+                ActorDto.from(notification.getActor()),
                 notification.getCreatedAt(),
                 readAt
         );

--- a/src/main/java/com/back/domain/notification/dto/NotificationWebSocketDto.java
+++ b/src/main/java/com/back/domain/notification/dto/NotificationWebSocketDto.java
@@ -1,5 +1,6 @@
 package com.back.domain.notification.dto;
 
+import com.back.domain.notification.entity.Notification;
 import com.back.domain.notification.entity.NotificationType;
 
 import java.time.LocalDateTime;
@@ -10,24 +11,18 @@ public record NotificationWebSocketDto(
         String message,
         NotificationType notificationType,
         String targetUrl,
+        ActorDto actor,
         LocalDateTime createdAt
 ) {
-
-    public static NotificationWebSocketDto from(
-            Long notificationId,
-            String title,
-            String content,
-            NotificationType type,
-            String targetUrl,
-            LocalDateTime createdAt) {
-
+    public static NotificationWebSocketDto from(Notification notification) {
         return new NotificationWebSocketDto(
-                notificationId,
-                title,
-                content,
-                type,
-                targetUrl,
-                createdAt
+                notification.getId(),
+                notification.getTitle(),
+                notification.getContent(),
+                notification.getType(),
+                notification.getTargetUrl(),
+                ActorDto.from(notification.getActor()),
+                notification.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/back/domain/notification/entity/Notification.java
+++ b/src/main/java/com/back/domain/notification/entity/Notification.java
@@ -20,22 +20,22 @@ public class Notification extends BaseEntity {
     private NotificationType type;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @JoinColumn(name = "receiver_id")
+    private User receiver; // 수신자 (누가 받는지)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id")
+    private User actor;  // 발신자 (누가 이 활동을 했는지)
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")
     private Room room;
 
     @Column(nullable = false)
-    private String title;
+    private String title; // 알림 제목 (필수)
 
-    @Column(columnDefinition = "TEXT", nullable = false)
-    private String content;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private NotificationStatus status;
+    @Column(columnDefinition = "TEXT")
+    private String content; // 알림 본문 또는 댓글 미리보기 (선택)
 
     private String targetUrl;
 
@@ -47,38 +47,53 @@ public class Notification extends BaseEntity {
         this.title = title;
         this.content = content;
         this.targetUrl = targetUrl;
-        this.status = NotificationStatus.UNREAD;
     }
 
     // 개인 알림 생성
-    public static Notification createPersonalNotification(User user, String title, String content, String targetUrl) {
+    public static Notification createPersonalNotification(
+            User receiver,
+            User actor,
+            String title,
+            String content,
+            String targetUrl) {
         Notification notification = new Notification(NotificationType.PERSONAL, title, content, targetUrl);
-        notification.user = user;
+        notification.receiver = receiver;
+        notification.actor = actor;
         return notification;
     }
 
     // 스터디룸 알림 생성
-    public static Notification createRoomNotification(Room room, String title, String content, String targetUrl) {
+    public static Notification createRoomNotification(
+            Room room,
+            User actor,
+            String title,
+            String content,
+            String targetUrl) {
         Notification notification = new Notification(NotificationType.ROOM, title, content, targetUrl);
         notification.room = room;
+        notification.actor = actor;
         return notification;
     }
 
-    // 시스템 알림 생성
-    public static Notification createSystemNotification(String title, String content, String targetUrl) {
+    // 시스템 알림 생성 (발신자 없음, 모두에게 전달)
+    public static Notification createSystemNotification(
+            String title,
+            String content,
+            String targetUrl) {
         return new Notification(NotificationType.SYSTEM, title, content, targetUrl);
     }
 
-    // 커뮤니티 알림 생성
-    public static Notification createCommunityNotification(User user, String title, String content, String targetUrl) {
+    // 커뮤니티 알림 생성 (댓글, 좋아요 등)
+    public static Notification createCommunityNotification(
+            User receiver,      // 수신자 (게시글 작성자)
+            User actor,         // 발신자 (댓글 작성자)
+            String title,
+            String content,
+            String targetUrl) {
         Notification notification = new Notification(NotificationType.COMMUNITY, title, content, targetUrl);
-        notification.user = user;
+        notification.receiver = receiver;
+        notification.actor = actor;
         return notification;
-    }
-
-    // 알림을 읽음 상태로 변경
-    public void markAsRead() {
-        this.status = NotificationStatus.READ;
     }
 
     // 전체 알림인지 확인
@@ -93,13 +108,18 @@ public class Notification extends BaseEntity {
 
     // 특정 유저에게 표시되어야 하는 알림인지 확인
     public boolean isVisibleToUser(Long userId) {
-
         // 시스템 알림은 모두에게 표시
         if (isSystemNotification()) {
             return true;
         }
 
-        // 개인 알림은 해당 유저에게만 표시
-        return user != null && user.getId().equals(userId);
+        // 개인/커뮤니티 알림은 수신자에게만 표시
+        return receiver != null && receiver.getId().equals(userId);
+    }
+
+    // 특정 유저가 이 알림을 읽었는지 확인
+    public boolean isReadBy(Long userId) {
+        return notificationReads.stream()
+                .anyMatch(read -> read.getUser().getId().equals(userId));
     }
 }

--- a/src/main/java/com/back/domain/notification/entity/NotificationStatus.java
+++ b/src/main/java/com/back/domain/notification/entity/NotificationStatus.java
@@ -1,6 +1,0 @@
-package com.back.domain.notification.entity;
-
-public enum NotificationStatus {
-    UNREAD,  // 읽지 않음
-    READ     // 읽음
-}

--- a/src/main/java/com/back/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/back/domain/notification/repository/NotificationRepository.java
@@ -5,37 +5,10 @@ import com.back.domain.notification.entity.NotificationType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
-
-    // 특정 유저의 알림 목록 조회 (개인 알림 + 시스템 알림)
-    @Query("SELECT n FROM Notification n " +
-            "WHERE n.user.id = :userId OR n.type = 'SYSTEM' " +
-            "ORDER BY n.createdAt DESC")
-    Page<Notification> findByUserIdOrSystemType(@Param("userId") Long userId, Pageable pageable);
-
-    // 특정 유저의 읽지 않은 알림 개수 조회
-    @Query("SELECT COUNT(n) FROM Notification n " +
-            "LEFT JOIN NotificationRead nr ON n.id = nr.notification.id AND nr.user.id = :userId " +
-            "WHERE (n.user.id = :userId OR n.type = 'SYSTEM') " +
-            "AND nr.id IS NULL")
-    long countUnreadByUserId(@Param("userId") Long userId);
-
-    // 특정 유저의 읽지 않은 알림 목록 조회
-    @Query("SELECT n FROM Notification n " +
-            "LEFT JOIN NotificationRead nr ON n.id = nr.notification.id AND nr.user.id = :userId " +
-            "WHERE (n.user.id = :userId OR n.type = 'SYSTEM') " +
-            "AND nr.id IS NULL " +
-            "ORDER BY n.createdAt DESC")
-    Page<Notification> findUnreadByUserId(@Param("userId") Long userId, Pageable pageable);
-
-    // 특정 스터디룸의 알림 조회
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
     Page<Notification> findByRoomIdOrderByCreatedAtDesc(Long roomId, Pageable pageable);
-
-    // 특정 타입의 알림 조회
     List<Notification> findByType(NotificationType type);
 }

--- a/src/main/java/com/back/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/back/domain/notification/repository/NotificationRepository.java
@@ -9,6 +9,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+    // 특정 스터디룸의 알림 조회
     Page<Notification> findByRoomIdOrderByCreatedAtDesc(Long roomId, Pageable pageable);
+
+    // 특정 타입의 알림 조회
     List<Notification> findByType(NotificationType type);
 }

--- a/src/main/java/com/back/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/back/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.back.domain.notification.repository;
+
+import com.back.domain.notification.entity.Notification;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface NotificationRepositoryCustom {
+    Page<Notification> findByUserIdOrSystemType(Long userId, Pageable pageable);
+    long countUnreadByUserId(Long userId);
+    Page<Notification> findUnreadByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/back/domain/notification/repository/NotificationRepositoryCustom.java
+++ b/src/main/java/com/back/domain/notification/repository/NotificationRepositoryCustom.java
@@ -1,11 +1,19 @@
 package com.back.domain.notification.repository;
 
 import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.entity.NotificationType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface NotificationRepositoryCustom {
+    // 특정 유저의 알림 목록 조회 (개인 알림 + 시스템 알림)
     Page<Notification> findByUserIdOrSystemType(Long userId, Pageable pageable);
+
+    // 특정 유저의 읽지 않은 알림 개수 조회
     long countUnreadByUserId(Long userId);
+
+    // 특정 유저의 읽지 않은 알림 목록 조회
     Page<Notification> findUnreadByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/back/domain/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/com/back/domain/notification/repository/NotificationRepositoryImpl.java
@@ -1,0 +1,140 @@
+package com.back.domain.notification.repository;
+
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.entity.NotificationType;
+import com.back.domain.notification.entity.QNotification;
+import com.back.domain.notification.entity.QNotificationRead;
+import com.back.domain.studyroom.entity.QRoomMember;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Notification> findByUserIdOrSystemType(Long userId, Pageable pageable) {
+        QNotification notification = QNotification.notification;
+        QRoomMember roomMember = QRoomMember.roomMember;
+
+        // user_id가 일치하는 알림 (PERSONAL + COMMUNITY)
+        BooleanExpression condition = notification.user.id.eq(userId)
+                // 시스템 알림 (모두에게)
+                .or(notification.type.eq(NotificationType.SYSTEM))
+                // 내가 멤버인 스터디룸의 알림
+                .or(
+                        notification.type.eq(NotificationType.ROOM)
+                                .and(notification.room.id.in(
+                                        JPAExpressions
+                                                // 서브쿼리 : 내가 멤버인 방 ID들
+                                                .select(roomMember.room.id)
+                                                .from(roomMember)
+                                                .where(roomMember.user.id.eq(userId))
+                                ))
+                );
+
+        List<Notification> content = queryFactory
+                .selectFrom(notification)
+                .where(condition)
+                .orderBy(notification.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(notification.count())
+                .from(notification)
+                .where(condition)
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    @Override
+    public long countUnreadByUserId(Long userId) {
+        QNotification notification = QNotification.notification;
+        QNotificationRead notificationRead = QNotificationRead.notificationRead;
+        QRoomMember roomMember = QRoomMember.roomMember;
+
+        BooleanExpression notificationCondition = notification.user.id.eq(userId)
+                .or(notification.type.eq(NotificationType.SYSTEM))
+                .or(
+                        notification.type.eq(NotificationType.ROOM)
+                                .and(notification.room.id.in(
+                                        JPAExpressions
+                                                .select(roomMember.room.id)
+                                                .from(roomMember)
+                                                .where(roomMember.user.id.eq(userId))
+                                ))
+                );
+
+        Long count = queryFactory
+                .select(notification.count())
+                .from(notification)
+                .leftJoin(notificationRead)
+                .on(notification.id.eq(notificationRead.notification.id)
+                        .and(notificationRead.user.id.eq(userId)))
+                .where(
+                        notificationCondition,
+                        notificationRead.id.isNull()
+                )
+                .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
+    @Override
+    public Page<Notification> findUnreadByUserId(Long userId, Pageable pageable) {
+        QNotification notification = QNotification.notification;
+        QNotificationRead notificationRead = QNotificationRead.notificationRead;
+        QRoomMember roomMember = QRoomMember.roomMember;
+
+        BooleanExpression notificationCondition = notification.user.id.eq(userId)
+                .or(notification.type.eq(NotificationType.SYSTEM))
+                .or(
+                        notification.type.eq(NotificationType.ROOM)
+                                .and(notification.room.id.in(
+                                        JPAExpressions
+                                                .select(roomMember.room.id)
+                                                .from(roomMember)
+                                                .where(roomMember.user.id.eq(userId))
+                                ))
+                );
+
+        List<Notification> content = queryFactory
+                .selectFrom(notification)
+                .leftJoin(notificationRead)
+                .on(notification.id.eq(notificationRead.notification.id)
+                        .and(notificationRead.user.id.eq(userId)))
+                .where(
+                        notificationCondition,
+                        notificationRead.id.isNull()
+                )
+                .orderBy(notification.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(notification.count())
+                .from(notification)
+                .leftJoin(notificationRead)
+                .on(notification.id.eq(notificationRead.notification.id)
+                        .and(notificationRead.user.id.eq(userId)))
+                .where(
+                        notificationCondition,
+                        notificationRead.id.isNull()
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+}

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -63,6 +63,9 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_001", "존재하지 않는 알림입니다."),
     NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "알림에 대한 접근 권한이 없습니다."),
     NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "NOTIFICATION_003", "이미 읽은 알림입니다."),
+    NOTIFICATION_INVALID_TARGET_TYPE(HttpStatus.BAD_REQUEST, "NOTIFICATION_004", "유효하지 않은 알림 타입입니다."),
+    NOTIFICATION_MISSING_ACTOR(HttpStatus.BAD_REQUEST, "NOTIFICATION_005", "발신자 정보가 필요합니다."),
+    NOTIFICATION_MISSING_TARGET(HttpStatus.BAD_REQUEST, "NOTIFICATION_006", "수신자 또는 대상 정보가 필요합니다."),
 
     // ======================== 메시지 관련 ========================
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MESSAGE_001", "존재하지 않는 메시지입니다."),

--- a/src/test/java/com/back/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/back/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,273 @@
+package com.back.domain.notification.controller;
+
+import com.back.domain.notification.dto.NotificationCreateRequest;
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.service.NotificationService;
+import com.back.domain.studyroom.repository.RoomRepository;
+import com.back.domain.user.entity.Role;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.exception.CustomException;
+import com.back.global.exception.ErrorCode;
+import com.back.global.security.jwt.JwtTokenProvider;
+import com.back.global.security.user.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NotificationControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private RoomRepository roomRepository;
+
+    private User receiver;
+    private User actor;
+    private Notification notification;
+    private CustomUserDetails mockUser;
+
+    @BeforeEach
+    void setUp() {
+        receiver = User.builder()
+                .id(1L)
+                .email("receiver@test.com")
+                .username("수신자")
+                .password("password123")
+                .role(Role.USER)
+                .build();
+
+        actor = User.builder()
+                .id(2L)
+                .email("actor@test.com")
+                .username("발신자")
+                .password("password123")
+                .role(Role.USER)
+                .build();
+
+        notification = Notification.createPersonalNotification(
+                receiver, actor, "테스트 알림", "내용", "/target"
+        );
+
+        // JWT Mock 설정
+        mockUser = CustomUserDetails.builder()
+                .userId(1L)
+                .username("testuser")
+                .role(Role.USER)
+                .build();
+
+        given(jwtTokenProvider.validateAccessToken("faketoken")).willReturn(true);
+        given(jwtTokenProvider.getAuthentication("faketoken"))
+                .willReturn(new UsernamePasswordAuthenticationToken(
+                        mockUser,
+                        null,
+                        List.of(new SimpleGrantedAuthority("ROLE_USER"))
+                ));
+    }
+
+    @Nested
+    @DisplayName("알림 전송")
+    class CreateNotificationTest {
+
+        @Test
+        @DisplayName("개인 알림 생성 성공")
+        void t1() throws Exception {
+            // given
+            NotificationCreateRequest request = new NotificationCreateRequest(
+                    "USER", 1L, 2L, "개인 알림", "내용", "/target"
+            );
+
+            given(userRepository.findById(1L)).willReturn(Optional.of(receiver));
+            given(userRepository.findById(2L)).willReturn(Optional.of(actor));
+            given(notificationService.createPersonalNotification(any(), any(), any(), any(), any()))
+                    .willReturn(notification);
+
+            // when
+            ResultActions result = mockMvc.perform(post("/api/notifications")
+                    .header("Authorization", "Bearer faketoken")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)));
+
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 목록 조회")
+    class GetNotificationsTest {
+
+        @Test
+        @DisplayName("알림 목록 조회 성공")
+        void t1() throws Exception {
+            // given
+            Page<Notification> notificationPage = new PageImpl<>(List.of(notification));
+
+            given(notificationService.getUserNotifications(anyLong(), any(Pageable.class)))
+                    .willReturn(notificationPage);
+            given(notificationService.getUnreadCount(anyLong())).willReturn(3L);
+            given(notificationService.isNotificationRead(anyLong(), anyLong())).willReturn(false);
+
+            // when
+            ResultActions result = mockMvc.perform(get("/api/notifications")
+                    .header("Authorization", "Bearer faketoken")
+                    .param("page", "0")
+                    .param("size", "20"));
+
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+        }
+
+        @Test
+        @DisplayName("읽지 않은 알림만 조회")
+        void t2() throws Exception {
+            // given
+            Page<Notification> notificationPage = new PageImpl<>(List.of(notification));
+
+            given(notificationService.getUnreadNotifications(anyLong(), any(Pageable.class)))
+                    .willReturn(notificationPage);
+            given(notificationService.getUnreadCount(anyLong())).willReturn(1L);
+            given(notificationService.isNotificationRead(anyLong(), anyLong())).willReturn(false);
+
+            // when
+            ResultActions result = mockMvc.perform(get("/api/notifications")
+                    .header("Authorization", "Bearer faketoken")
+                    .param("unreadOnly", "true"));
+
+            // then
+            result.andExpect(status().isOk());
+            verify(notificationService).getUnreadNotifications(anyLong(), any(Pageable.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 읽음 처리")
+    class MarkAsReadTest {
+
+        @Test
+        @DisplayName("알림 읽음 처리 성공")
+        void t1() throws Exception {
+            // given
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(receiver));
+            given(notificationService.getNotification(1L)).willReturn(notification);
+            given(notificationService.isNotificationRead(1L, receiver.getId())).willReturn(true);
+
+            // when
+            ResultActions result = mockMvc.perform(put("/api/notifications/1/read")
+                    .header("Authorization", "Bearer faketoken"));
+
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            verify(notificationService).markAsRead(eq(1L), any(User.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림 - 404 에러")
+        void t2() throws Exception {
+            // given
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(receiver));
+            given(notificationService.getNotification(999L))
+                    .willThrow(new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+            // when
+            ResultActions result = mockMvc.perform(put("/api/notifications/999/read")
+                    .header("Authorization", "Bearer faketoken"));
+
+            // then
+            result.andExpect(status().isNotFound());
+        }
+
+        @Test
+        @DisplayName("이미 읽은 알림 - 400 에러")
+        void t3() throws Exception {
+            // given
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(receiver));
+            willThrow(new CustomException(ErrorCode.NOTIFICATION_ALREADY_READ))
+                    .given(notificationService).markAsRead(eq(1L), any(User.class));
+
+            // when
+            ResultActions result = mockMvc.perform(put("/api/notifications/1/read")
+                    .header("Authorization", "Bearer faketoken"));
+
+            // then
+            result.andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 읽음 처리")
+    class MarkAllAsReadTest {
+
+        @Test
+        @DisplayName("전체 알림 읽음 처리 성공")
+        void t1() throws Exception {
+            // given
+            given(userRepository.findById(anyLong())).willReturn(Optional.of(receiver));
+
+            // when
+            ResultActions result = mockMvc.perform(put("/api/notifications/read-all")
+                    .header("Authorization", "Bearer faketoken"));
+
+            // then
+            result.andExpect(status().isOk())
+                    .andExpect(jsonPath("$.success").value(true));
+
+            verify(notificationService).markMultipleAsRead(anyLong(), any(User.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자 - 404 에러")
+        void t2() throws Exception {
+            // given
+            given(userRepository.findById(anyLong())).willReturn(Optional.empty());
+
+            // when
+            ResultActions result = mockMvc.perform(put("/api/notifications/read-all")
+                    .header("Authorization", "Bearer faketoken"));
+
+            // then
+            result.andExpect(status().isNotFound());
+        }
+    }
+}

--- a/src/test/java/com/back/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/back/domain/notification/repository/NotificationRepositoryTest.java
@@ -52,6 +52,7 @@ class NotificationRepositoryTest {
 
     private User user1;
     private User user2;
+    private User actor;
     private Room room1;
     private Room room2;
 
@@ -68,7 +69,12 @@ class NotificationRepositoryTest {
                 .username("유저2")
                 .password("password123")
                 .build();
-        userRepository.saveAll(List.of(user1, user2));
+        actor = User.builder()
+                .email("actor@test.com")
+                .username("발신자")
+                .password("password123")
+                .build();
+        userRepository.saveAll(List.of(user1, user2, actor));
 
         // 테스트 스터디룸 생성
         room1 = Room.builder()
@@ -102,7 +108,7 @@ class NotificationRepositoryTest {
         void t1() {
             // given
             Notification personalNotification = Notification.createPersonalNotification(
-                    user1, "개인 알림", "내용", "/target"
+                    user1, actor, "개인 알림", "내용", "/target"
             );
             notificationRepository.save(personalNotification);
 
@@ -147,10 +153,10 @@ class NotificationRepositoryTest {
             // given
             // user1이 속한 room1, room2의 알림
             Notification roomNotification1 = Notification.createRoomNotification(
-                    room1, "스터디룸1 알림", "내용", "/room/1"
+                    room1, actor, "스터디룸1 알림", "내용", "/room/1"
             );
             Notification roomNotification2 = Notification.createRoomNotification(
-                    room2, "스터디룸2 알림", "내용", "/room/2"
+                    room2, actor, "스터디룸2 알림", "내용", "/room/2"
             );
             notificationRepository.saveAll(List.of(roomNotification1, roomNotification2));
 
@@ -179,7 +185,7 @@ class NotificationRepositoryTest {
             roomRepository.save(otherRoom);
 
             Notification otherRoomNotification = Notification.createRoomNotification(
-                    otherRoom, "다른 방 알림", "내용", "/room/other"
+                    otherRoom, actor, "다른 방 알림", "내용", "/room/other"
             );
             notificationRepository.save(otherRoomNotification);
 
@@ -198,16 +204,16 @@ class NotificationRepositoryTest {
         void t5() {
             // given
             Notification personal = Notification.createPersonalNotification(
-                    user1, "개인", "내용", "/p"
+                    user1, actor, "개인", "내용", "/p"
             );
             Notification system = Notification.createSystemNotification(
                     "시스템", "내용", "/s"
             );
             Notification room = Notification.createRoomNotification(
-                    room1, "스터디룸", "내용", "/r"
+                    room1, actor, "스터디룸", "내용", "/r"
             );
             Notification community = Notification.createCommunityNotification(
-                    user1, "커뮤니티", "내용", "/c"
+                    user1, actor, "커뮤니티", "내용", "/c"
             );
             notificationRepository.saveAll(List.of(personal, system, room, community));
 
@@ -234,14 +240,14 @@ class NotificationRepositoryTest {
         void t6() throws InterruptedException {
             // given
             Notification old = Notification.createPersonalNotification(
-                    user1, "오래된 알림", "내용", "/old"
+                    user1, actor, "오래된 알림", "내용", "/old"
             );
             notificationRepository.save(old);
 
             Thread.sleep(100); // 시간 차이를 위한 대기
 
             Notification recent = Notification.createPersonalNotification(
-                    user1, "최근 알림", "내용", "/recent"
+                    user1, actor, "최근 알림", "내용", "/recent"
             );
             notificationRepository.save(recent);
 
@@ -263,7 +269,7 @@ class NotificationRepositoryTest {
             // given
             for (int i = 1; i <= 15; i++) {
                 Notification notification = Notification.createPersonalNotification(
-                        user1, "알림 " + i, "내용", "/target"
+                        user1, actor, "알림 " + i, "내용", "/target"
                 );
                 notificationRepository.save(notification);
             }
@@ -290,10 +296,10 @@ class NotificationRepositoryTest {
         void t1() {
             // given
             Notification notification1 = Notification.createPersonalNotification(
-                    user1, "알림1", "내용", "/1"
+                    user1, actor, "알림1", "내용", "/1"
             );
             Notification notification2 = Notification.createPersonalNotification(
-                    user1, "알림2", "내용", "/2"
+                    user1, actor, "알림2", "내용", "/2"
             );
             notificationRepository.saveAll(List.of(notification1, notification2));
 
@@ -309,10 +315,10 @@ class NotificationRepositoryTest {
         void t2() {
             // given
             Notification notification1 = Notification.createPersonalNotification(
-                    user1, "알림1", "내용", "/1"
+                    user1, actor, "알림1", "내용", "/1"
             );
             Notification notification2 = Notification.createPersonalNotification(
-                    user1, "알림2", "내용", "/2"
+                    user1, actor, "알림2", "내용", "/2"
             );
             notificationRepository.saveAll(List.of(notification1, notification2));
 
@@ -348,7 +354,7 @@ class NotificationRepositoryTest {
         void t4() {
             // given
             Notification roomNotification = Notification.createRoomNotification(
-                    room1, "스터디룸 알림", "내용", "/room"
+                    room1, actor, "스터디룸 알림", "내용", "/room"
             );
             notificationRepository.save(roomNotification);
 
@@ -369,10 +375,10 @@ class NotificationRepositoryTest {
         void t1() {
             // given
             Notification unread = Notification.createPersonalNotification(
-                    user1, "읽지 않음", "내용", "/unread"
+                    user1, actor, "읽지 않음", "내용", "/unread"
             );
             Notification read = Notification.createPersonalNotification(
-                    user1, "읽음", "내용", "/read"
+                    user1, actor, "읽음", "내용", "/read"
             );
             notificationRepository.saveAll(List.of(unread, read));
 
@@ -396,13 +402,13 @@ class NotificationRepositoryTest {
         void t2() {
             // given
             Notification personal = Notification.createPersonalNotification(
-                    user1, "개인", "내용", "/p"
+                    user1, actor, "개인", "내용", "/p"
             );
             Notification system = Notification.createSystemNotification(
                     "시스템", "내용", "/s"
             );
             Notification room = Notification.createRoomNotification(
-                    room1, "스터디룸", "내용", "/r"
+                    room1, actor, "스터디룸", "내용", "/r"
             );
             notificationRepository.saveAll(List.of(personal, system, room));
 
@@ -421,14 +427,14 @@ class NotificationRepositoryTest {
         void t3() throws InterruptedException {
             // given
             Notification old = Notification.createPersonalNotification(
-                    user1, "오래된", "내용", "/old"
+                    user1, actor, "오래된", "내용", "/old"
             );
             notificationRepository.save(old);
 
             Thread.sleep(100);
 
             Notification recent = Notification.createPersonalNotification(
-                    user1, "최근", "내용", "/recent"
+                    user1, actor, "최근", "내용", "/recent"
             );
             notificationRepository.save(recent);
 
@@ -453,10 +459,10 @@ class NotificationRepositoryTest {
         void t1() {
             // given
             Notification notification1 = Notification.createRoomNotification(
-                    room1, "방1 알림", "내용", "/1"
+                    room1, actor, "방1 알림", "내용", "/1"
             );
             Notification notification2 = Notification.createRoomNotification(
-                    room2, "방2 알림", "내용", "/2"
+                    room2, actor, "방2 알림", "내용", "/2"
             );
             notificationRepository.saveAll(List.of(notification1, notification2));
 
@@ -482,7 +488,7 @@ class NotificationRepositoryTest {
                     "시스템2", "내용", "/2"
             );
             Notification personal = Notification.createPersonalNotification(
-                    user1, "개인", "내용", "/p"
+                    user1, actor, "개인", "내용", "/p"
             );
             notificationRepository.saveAll(List.of(system1, system2, personal));
 

--- a/src/test/java/com/back/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/back/domain/notification/repository/NotificationRepositoryTest.java
@@ -28,8 +28,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(QueryDslTestConfig.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class NotificationRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/back/domain/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/back/domain/notification/repository/NotificationRepositoryTest.java
@@ -1,0 +1,500 @@
+package com.back.domain.notification.repository;
+
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.entity.NotificationRead;
+import com.back.domain.notification.entity.NotificationType;
+import com.back.domain.studyroom.entity.Room;
+import com.back.domain.studyroom.entity.RoomMember;
+import com.back.domain.studyroom.repository.RoomMemberRepository;
+import com.back.domain.studyroom.repository.RoomRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.config.QueryDslTestConfig;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QueryDslTestConfig.class)
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    @Autowired
+    private NotificationReadRepository notificationReadRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Autowired
+    private RoomMemberRepository roomMemberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private User user1;
+    private User user2;
+    private Room room1;
+    private Room room2;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 생성
+        user1 = User.builder()
+                .email("user1@test.com")
+                .username("유저1")
+                .password("password123")
+                .build();
+        user2 = User.builder()
+                .email("user2@test.com")
+                .username("유저2")
+                .password("password123")
+                .build();
+        userRepository.saveAll(List.of(user1, user2));
+
+        // 테스트 스터디룸 생성
+        room1 = Room.builder()
+                .title("스터디룸1")
+                .description("설명1")
+                .createdBy(user1)
+                .build();
+        room2 = Room.builder()
+                .title("스터디룸2")
+                .description("설명2")
+                .createdBy(user2)
+                .build();
+        roomRepository.saveAll(List.of(room1, room2));
+
+        // user1은 room1의 멤버
+        RoomMember member1 = RoomMember.createHost(room1, user1);
+        // user1은 room2의 멤버
+        RoomMember member2 = RoomMember.createMember(room2, user1);
+        roomMemberRepository.saveAll(List.of(member1, member2));
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Nested
+    @DisplayName("findByUserIdOrSystemType 테스트")
+    class FindByUserIdOrSystemTypeTest {
+
+        @Test
+        @DisplayName("개인 알림 조회")
+        void t1() {
+            // given
+            Notification personalNotification = Notification.createPersonalNotification(
+                    user1, "개인 알림", "내용", "/target"
+            );
+            notificationRepository.save(personalNotification);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByUserIdOrSystemType(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getType())
+                    .isEqualTo(NotificationType.PERSONAL);
+            assertThat(result.getContent().get(0).getTitle())
+                    .isEqualTo("개인 알림");
+        }
+
+        @Test
+        @DisplayName("시스템 알림 조회")
+        void t2() {
+            // given
+            Notification systemNotification = Notification.createSystemNotification(
+                    "시스템 알림", "전체 공지", "/notice"
+            );
+            notificationRepository.save(systemNotification);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByUserIdOrSystemType(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getType())
+                    .isEqualTo(NotificationType.SYSTEM);
+        }
+
+        @Test
+        @DisplayName("내가 멤버인 스터디룸 알림 조회")
+        void t3() {
+            // given
+            // user1이 속한 room1, room2의 알림
+            Notification roomNotification1 = Notification.createRoomNotification(
+                    room1, "스터디룸1 알림", "내용", "/room/1"
+            );
+            Notification roomNotification2 = Notification.createRoomNotification(
+                    room2, "스터디룸2 알림", "내용", "/room/2"
+            );
+            notificationRepository.saveAll(List.of(roomNotification1, roomNotification2));
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByUserIdOrSystemType(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent())
+                    .extracting(Notification::getType)
+                    .containsOnly(NotificationType.ROOM);
+        }
+
+        @Test
+        @DisplayName("내가 멤버가 아닌 스터디룸 알림 조회 불가")
+        void t4() {
+            // given
+            Room otherRoom = Room.builder()
+                    .title("다른 방")
+                    .description("설명")
+                    .createdBy(user2)
+                    .build();
+            roomRepository.save(otherRoom);
+
+            Notification otherRoomNotification = Notification.createRoomNotification(
+                    otherRoom, "다른 방 알림", "내용", "/room/other"
+            );
+            notificationRepository.save(otherRoomNotification);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByUserIdOrSystemType(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("모든 타입의 알림 함께 조회")
+        void t5() {
+            // given
+            Notification personal = Notification.createPersonalNotification(
+                    user1, "개인", "내용", "/p"
+            );
+            Notification system = Notification.createSystemNotification(
+                    "시스템", "내용", "/s"
+            );
+            Notification room = Notification.createRoomNotification(
+                    room1, "스터디룸", "내용", "/r"
+            );
+            Notification community = Notification.createCommunityNotification(
+                    user1, "커뮤니티", "내용", "/c"
+            );
+            notificationRepository.saveAll(List.of(personal, system, room, community));
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByUserIdOrSystemType(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(4);
+            assertThat(result.getContent())
+                    .extracting(Notification::getType)
+                    .containsExactlyInAnyOrder(
+                            NotificationType.PERSONAL,
+                            NotificationType.SYSTEM,
+                            NotificationType.ROOM,
+                            NotificationType.COMMUNITY
+                    );
+        }
+
+        @Test
+        @DisplayName("생성일시 내림차순 정렬")
+        void t6() throws InterruptedException {
+            // given
+            Notification old = Notification.createPersonalNotification(
+                    user1, "오래된 알림", "내용", "/old"
+            );
+            notificationRepository.save(old);
+
+            Thread.sleep(100); // 시간 차이를 위한 대기
+
+            Notification recent = Notification.createPersonalNotification(
+                    user1, "최근 알림", "내용", "/recent"
+            );
+            notificationRepository.save(recent);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByUserIdOrSystemType(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent().get(0).getTitle()).isEqualTo("최근 알림");
+            assertThat(result.getContent().get(1).getTitle()).isEqualTo("오래된 알림");
+        }
+
+        @Test
+        @DisplayName("페이징 정상 작동")
+        void t7() {
+            // given
+            for (int i = 1; i <= 15; i++) {
+                Notification notification = Notification.createPersonalNotification(
+                        user1, "알림 " + i, "내용", "/target"
+                );
+                notificationRepository.save(notification);
+            }
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByUserIdOrSystemType(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(10);
+            assertThat(result.getTotalElements()).isEqualTo(15);
+            assertThat(result.getTotalPages()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("countUnreadByUserId 테스트")
+    class CountUnreadByUserIdTest {
+
+        @Test
+        @DisplayName("읽지 않은 개인 알림 개수 조회")
+        void t1() {
+            // given
+            Notification notification1 = Notification.createPersonalNotification(
+                    user1, "알림1", "내용", "/1"
+            );
+            Notification notification2 = Notification.createPersonalNotification(
+                    user1, "알림2", "내용", "/2"
+            );
+            notificationRepository.saveAll(List.of(notification1, notification2));
+
+            // when
+            long count = notificationRepository.countUnreadByUserId(user1.getId());
+
+            // then
+            assertThat(count).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("읽은 알림은 알림 개수에 포함 X")
+        void t2() {
+            // given
+            Notification notification1 = Notification.createPersonalNotification(
+                    user1, "알림1", "내용", "/1"
+            );
+            Notification notification2 = Notification.createPersonalNotification(
+                    user1, "알림2", "내용", "/2"
+            );
+            notificationRepository.saveAll(List.of(notification1, notification2));
+
+            // notification1을 읽음 처리
+            NotificationRead read = NotificationRead.create(notification1, user1);
+            notificationReadRepository.save(read);
+
+            // when
+            long count = notificationRepository.countUnreadByUserId(user1.getId());
+
+            // then
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("시스템 알림도 읽지 않은 개수에 포함")
+        void t3() {
+            // given
+            Notification systemNotification = Notification.createSystemNotification(
+                    "시스템 알림", "내용", "/system"
+            );
+            notificationRepository.save(systemNotification);
+
+            // when
+            long count = notificationRepository.countUnreadByUserId(user1.getId());
+
+            // then
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("스터디룸 알림도 읽지 않은 개수에 포함")
+        void t4() {
+            // given
+            Notification roomNotification = Notification.createRoomNotification(
+                    room1, "스터디룸 알림", "내용", "/room"
+            );
+            notificationRepository.save(roomNotification);
+
+            // when
+            long count = notificationRepository.countUnreadByUserId(user1.getId());
+
+            // then
+            assertThat(count).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("findUnreadByUserId 테스트")
+    class FindUnreadByUserIdTest {
+
+        @Test
+        @DisplayName("읽지 않은 알림만 조회")
+        void t1() {
+            // given
+            Notification unread = Notification.createPersonalNotification(
+                    user1, "읽지 않음", "내용", "/unread"
+            );
+            Notification read = Notification.createPersonalNotification(
+                    user1, "읽음", "내용", "/read"
+            );
+            notificationRepository.saveAll(List.of(unread, read));
+
+            // read 알림을 읽음 처리
+            NotificationRead notificationRead = NotificationRead.create(read, user1);
+            notificationReadRepository.save(notificationRead);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findUnreadByUserId(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getTitle()).isEqualTo("읽지 않음");
+        }
+
+        @Test
+        @DisplayName("모든 타입의 읽지 않은 알림 조회")
+        void t2() {
+            // given
+            Notification personal = Notification.createPersonalNotification(
+                    user1, "개인", "내용", "/p"
+            );
+            Notification system = Notification.createSystemNotification(
+                    "시스템", "내용", "/s"
+            );
+            Notification room = Notification.createRoomNotification(
+                    room1, "스터디룸", "내용", "/r"
+            );
+            notificationRepository.saveAll(List.of(personal, system, room));
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findUnreadByUserId(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("생성일시 내림차순으로 정렬")
+        void t3() throws InterruptedException {
+            // given
+            Notification old = Notification.createPersonalNotification(
+                    user1, "오래된", "내용", "/old"
+            );
+            notificationRepository.save(old);
+
+            Thread.sleep(100);
+
+            Notification recent = Notification.createPersonalNotification(
+                    user1, "최근", "내용", "/recent"
+            );
+            notificationRepository.save(recent);
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findUnreadByUserId(user1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent().get(0).getTitle()).isEqualTo("최근");
+            assertThat(result.getContent().get(1).getTitle()).isEqualTo("오래된");
+        }
+    }
+
+    @Nested
+    @DisplayName("단순 쿼리 메서드 테스트")
+    class SimpleQueryMethodTest {
+
+        @Test
+        @DisplayName("특정 스터디룸의 알림 조회")
+        void t1() {
+            // given
+            Notification notification1 = Notification.createRoomNotification(
+                    room1, "방1 알림", "내용", "/1"
+            );
+            Notification notification2 = Notification.createRoomNotification(
+                    room2, "방2 알림", "내용", "/2"
+            );
+            notificationRepository.saveAll(List.of(notification1, notification2));
+
+            Pageable pageable = PageRequest.of(0, 10);
+
+            // when
+            Page<Notification> result = notificationRepository
+                    .findByRoomIdOrderByCreatedAtDesc(room1.getId(), pageable);
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0).getTitle()).isEqualTo("방1 알림");
+        }
+
+        @Test
+        @DisplayName("특정 타입의 알림 조회")
+        void t2() {
+            // given
+            Notification system1 = Notification.createSystemNotification(
+                    "시스템1", "내용", "/1"
+            );
+            Notification system2 = Notification.createSystemNotification(
+                    "시스템2", "내용", "/2"
+            );
+            Notification personal = Notification.createPersonalNotification(
+                    user1, "개인", "내용", "/p"
+            );
+            notificationRepository.saveAll(List.of(system1, system2, personal));
+
+            // when
+            List<Notification> result = notificationRepository
+                    .findByType(NotificationType.SYSTEM);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result)
+                    .extracting(Notification::getType)
+                    .containsOnly(NotificationType.SYSTEM);
+        }
+    }
+}

--- a/src/test/java/com/back/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/back/domain/notification/service/NotificationServiceTest.java
@@ -1,0 +1,403 @@
+package com.back.domain.notification.service;
+
+import com.back.domain.notification.dto.NotificationWebSocketDto;
+import com.back.domain.notification.entity.Notification;
+import com.back.domain.notification.entity.NotificationRead;
+import com.back.domain.notification.entity.NotificationType;
+import com.back.domain.notification.repository.NotificationReadRepository;
+import com.back.domain.notification.repository.NotificationRepository;
+import com.back.domain.studyroom.entity.Room;
+import com.back.domain.user.entity.User;
+import com.back.global.exception.CustomException;
+import com.back.global.exception.ErrorCode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationReadRepository notificationReadRepository;
+
+    @Mock
+    private NotificationWebSocketService webSocketService;
+
+    @InjectMocks
+    private NotificationService notificationService;
+
+    private User user;
+    private Room room;
+    private Notification notification;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .username("테스터")
+                .password("password123")
+                .build();
+
+        room = Room.builder()
+                .id(1L)
+                .title("테스트룸")
+                .description("설명")
+                .createdBy(user)
+                .build();
+
+        notification = Notification.createPersonalNotification(
+                user, "테스트 알림", "내용", "/target"
+        );
+        ReflectionTestUtils.setField(notification, "id", 1L);
+    }
+
+    @Nested
+    @DisplayName("알림 생성 및 전송 테스트")
+    class CreateNotificationTest {
+
+        @Test
+        @DisplayName("개인 알림을 생성하고 WebSocket으로 전송")
+        void t1() {
+            // given
+            given(notificationRepository.save(any(Notification.class)))
+                    .willReturn(notification);
+
+            // when
+            Notification result = notificationService.createPersonalNotification(
+                    user, "테스트 알림", "내용", "/target"
+            );
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getType()).isEqualTo(NotificationType.PERSONAL);
+            assertThat(result.getUser()).isEqualTo(user);
+
+            verify(notificationRepository).save(any(Notification.class));
+            verify(webSocketService).sendNotificationToUser(
+                    eq(user.getId()),
+                    any(NotificationWebSocketDto.class)
+            );
+        }
+
+        @Test
+        @DisplayName("스터디룸 알림 생성 - 룸 멤버들에게 전송")
+        void t2() {
+            // given
+            Notification roomNotification = Notification.createRoomNotification(
+                    room, "룸 알림", "내용", "/room"
+            );
+            given(notificationRepository.save(any(Notification.class)))
+                    .willReturn(roomNotification);
+
+            // when
+            Notification result = notificationService.createRoomNotification(
+                    room, "룸 알림", "내용", "/room"
+            );
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getType()).isEqualTo(NotificationType.ROOM);
+            assertThat(result.getRoom()).isEqualTo(room);
+
+            verify(notificationRepository).save(any(Notification.class));
+            verify(webSocketService).sendNotificationToRoom(
+                    eq(room.getId()),
+                    any(NotificationWebSocketDto.class)
+            );
+        }
+
+        @Test
+        @DisplayName("시스템 알림 생성 - 전체 브로드캐스트")
+        void t3() {
+            // given
+            Notification systemNotification = Notification.createSystemNotification(
+                    "시스템 알림", "내용", "/system"
+            );
+            given(notificationRepository.save(any(Notification.class)))
+                    .willReturn(systemNotification);
+
+            // when
+            Notification result = notificationService.createSystemNotification(
+                    "시스템 알림", "내용", "/system"
+            );
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getType()).isEqualTo(NotificationType.SYSTEM);
+            assertThat(result.getUser()).isNull();
+            assertThat(result.getRoom()).isNull();
+
+            verify(notificationRepository).save(any(Notification.class));
+            verify(webSocketService).broadcastSystemNotification(
+                    any(NotificationWebSocketDto.class)
+            );
+        }
+
+        @Test
+        @DisplayName("커뮤니티 알림 생성 - WebSocket으로 전송")
+        void t4() {
+            // given
+            Notification communityNotification = Notification.createCommunityNotification(
+                    user, "커뮤니티 알림", "내용", "/community"
+            );
+            given(notificationRepository.save(any(Notification.class)))
+                    .willReturn(communityNotification);
+
+            // when
+            Notification result = notificationService.createCommunityNotification(
+                    user, "커뮤니티 알림", "내용", "/community"
+            );
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getType()).isEqualTo(NotificationType.COMMUNITY);
+            assertThat(result.getUser()).isEqualTo(user);
+
+            verify(notificationRepository).save(any(Notification.class));
+            verify(webSocketService).sendNotificationToUser(
+                    eq(user.getId()),
+                    any(NotificationWebSocketDto.class)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 조회 테스트")
+    class GetNotificationTest {
+
+        @Test
+        @DisplayName("유저의 알림 목록 조회")
+        void t1() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<Notification> expectedPage = new PageImpl<>(List.of(notification));
+            given(notificationRepository.findByUserIdOrSystemType(user.getId(), pageable))
+                    .willReturn(expectedPage);
+
+            // when
+            Page<Notification> result = notificationService.getUserNotifications(
+                    user.getId(), pageable
+            );
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            assertThat(result.getContent().get(0)).isEqualTo(notification);
+            verify(notificationRepository).findByUserIdOrSystemType(user.getId(), pageable);
+        }
+
+        @Test
+        @DisplayName("유저의 읽지 않은 알림 목록 조회")
+        void t2() {
+            // given
+            Pageable pageable = PageRequest.of(0, 10);
+            Page<Notification> expectedPage = new PageImpl<>(List.of(notification));
+            given(notificationRepository.findUnreadByUserId(user.getId(), pageable))
+                    .willReturn(expectedPage);
+
+            // when
+            Page<Notification> result = notificationService.getUnreadNotifications(
+                    user.getId(), pageable
+            );
+
+            // then
+            assertThat(result.getContent()).hasSize(1);
+            verify(notificationRepository).findUnreadByUserId(user.getId(), pageable);
+        }
+
+        @Test
+        @DisplayName("유저의 읽지 않은 알림 개수 조회")
+        void t3() {
+            // given
+            given(notificationRepository.countUnreadByUserId(user.getId()))
+                    .willReturn(5L);
+
+            // when
+            long count = notificationService.getUnreadCount(user.getId());
+
+            // then
+            assertThat(count).isEqualTo(5L);
+            verify(notificationRepository).countUnreadByUserId(user.getId());
+        }
+
+        @Test
+        @DisplayName("알림 단건 조회 - 성공")
+        void t4() {
+            // given
+            given(notificationRepository.findById(1L))
+                    .willReturn(Optional.of(notification));
+
+            // when
+            Notification result = notificationService.getNotification(1L);
+
+            // then
+            assertThat(result).isEqualTo(notification);
+            verify(notificationRepository).findById(1L);
+        }
+
+        @Test
+        @DisplayName("알림 단건 조회 - 존재하지 않는 알림")
+        void t5() {
+            // given
+            given(notificationRepository.findById(999L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.getNotification(999L))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTIFICATION_NOT_FOUND);
+
+            verify(notificationRepository).findById(999L);
+        }
+
+        @Test
+        @DisplayName("알림 읽음 여부 확인")
+        void t6() {
+            // given
+            given(notificationReadRepository.existsByNotificationIdAndUserId(1L, user.getId()))
+                    .willReturn(true);
+
+            // when
+            boolean result = notificationService.isNotificationRead(1L, user.getId());
+
+            // then
+            assertThat(result).isTrue();
+            verify(notificationReadRepository).existsByNotificationIdAndUserId(1L, user.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 읽음 처리 테스트")
+    class MarkAsReadTest {
+
+        @Test
+        @DisplayName("알림 읽음 처리 - 처음 읽는 알림")
+        void t1() {
+            // given
+            given(notificationRepository.findById(1L))
+                    .willReturn(Optional.of(notification));
+            given(notificationReadRepository.existsByNotificationIdAndUserId(1L, user.getId()))
+                    .willReturn(false);
+
+            // when
+            notificationService.markAsRead(1L, user);
+
+            // then
+            verify(notificationRepository).findById(1L);
+            verify(notificationReadRepository).existsByNotificationIdAndUserId(1L, user.getId());
+            verify(notificationReadRepository).save(any(NotificationRead.class));
+        }
+
+        @Test
+        @DisplayName("알림 읽음 처리 - 이미 읽은 알림")
+        void t2() {
+            // given
+            given(notificationRepository.findById(1L))
+                    .willReturn(Optional.of(notification));
+            given(notificationReadRepository.existsByNotificationIdAndUserId(1L, user.getId()))
+                    .willReturn(true);
+
+            // when
+            notificationService.markAsRead(1L, user);
+
+            // then
+            verify(notificationRepository).findById(1L);
+            verify(notificationReadRepository).existsByNotificationIdAndUserId(1L, user.getId());
+            verify(notificationReadRepository, never()).save(any(NotificationRead.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 알림 읽음 처리 시 예외 발생")
+        void t3() {
+            // given
+            given(notificationRepository.findById(999L))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> notificationService.markAsRead(999L, user))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTIFICATION_NOT_FOUND);
+
+            verify(notificationRepository).findById(999L);
+            verify(notificationReadRepository, never()).save(any(NotificationRead.class));
+        }
+
+        @Test
+        @DisplayName("여러 알림 일괄 읽음 처리")
+        void t4() {
+            // given
+            Notification notification2 = Notification.createPersonalNotification(
+                    user, "알림2", "내용2", "/target2"
+            );
+            ReflectionTestUtils.setField(notification2, "id", 2L);
+
+            Page<Notification> unreadPage = new PageImpl<>(
+                    List.of(notification, notification2)
+            );
+
+            given(notificationRepository.findUnreadByUserId(user.getId(), Pageable.unpaged()))
+                    .willReturn(unreadPage);
+            given(notificationReadRepository.existsByNotificationIdAndUserId(anyLong(), eq(user.getId())))
+                    .willReturn(false);
+
+            // when
+            notificationService.markMultipleAsRead(user.getId(), user);
+
+            // then
+            verify(notificationRepository).findUnreadByUserId(user.getId(), Pageable.unpaged());
+            verify(notificationReadRepository, times(2)).save(any(NotificationRead.class));
+        }
+
+        @Test
+        @DisplayName("일괄 읽음 처리 시 이미 읽은 알림 제외")
+        void t5() {
+            // given
+            Notification notification2 = Notification.createPersonalNotification(
+                    user, "알림2", "내용2", "/target2"
+            );
+            ReflectionTestUtils.setField(notification2, "id", 2L);
+
+            Page<Notification> unreadPage = new PageImpl<>(
+                    List.of(notification, notification2)
+            );
+
+            given(notificationRepository.findUnreadByUserId(user.getId(), Pageable.unpaged()))
+                    .willReturn(unreadPage);
+            given(notificationReadRepository.existsByNotificationIdAndUserId(1L, user.getId()))
+                    .willReturn(true); // 첫 번째 알림은 이미 읽음
+            given(notificationReadRepository.existsByNotificationIdAndUserId(2L, user.getId()))
+                    .willReturn(false); // 두 번째 알림은 안 읽음
+
+            // when
+            notificationService.markMultipleAsRead(user.getId(), user);
+
+            // then
+            verify(notificationRepository).findUnreadByUserId(user.getId(), Pageable.unpaged());
+            verify(notificationReadRepository, times(1)).save(any(NotificationRead.class));
+        }
+    }
+}

--- a/src/test/java/com/back/domain/notification/service/NotificationWebSocketServiceTest.java
+++ b/src/test/java/com/back/domain/notification/service/NotificationWebSocketServiceTest.java
@@ -1,0 +1,218 @@
+package com.back.domain.notification.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.verify;
+
+import com.back.domain.notification.dto.NotificationWebSocketDto;
+import com.back.domain.notification.entity.NotificationType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.LocalDateTime;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationWebSocketServiceTest {
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @InjectMocks
+    private NotificationWebSocketService webSocketService;
+
+    private NotificationWebSocketDto notificationDto;
+
+    @BeforeEach
+    void setUp() {
+        notificationDto = NotificationWebSocketDto.from(
+                1L,
+                "테스트 알림",
+                "알림 내용",
+                NotificationType.PERSONAL,
+                "/target",
+                LocalDateTime.now()
+        );
+    }
+
+    @Nested
+    @DisplayName("개인 알림 전송 테스트")
+    class SendNotificationToUserTest {
+
+        @Test
+        @DisplayName("특정 유저에게 알림 전송")
+        void t1() {
+            // given
+            Long userId = 1L;
+            String expectedDestination = "/topic/user/1/notifications";
+
+            // when
+            webSocketService.sendNotificationToUser(userId, notificationDto);
+
+            // then
+            verify(messagingTemplate).convertAndSend(
+                    eq(expectedDestination),
+                    eq(notificationDto)
+            );
+        }
+
+        @Test
+        @DisplayName("전송 실패 시 예외를 로깅하고 정상 종료")
+        void t2() {
+            // given
+            Long userId = 1L;
+            willThrow(new RuntimeException("전송 실패"))
+                    .given(messagingTemplate)
+                    .convertAndSend(anyString(), any(Object.class));
+
+            // when & then - 예외가 발생해도 메서드는 정상 종료되어야 함
+            webSocketService.sendNotificationToUser(userId, notificationDto);
+
+            verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("시스템 알림 브로드캐스트 테스트")
+    class BroadcastSystemNotificationTest {
+
+        @Test
+        @DisplayName("전체 유저에게 시스템 알림 브로드캐스트")
+        void t1() {
+            // given
+            String expectedDestination = "/topic/notifications/system";
+            NotificationWebSocketDto systemDto = NotificationWebSocketDto.from(
+                    2L,
+                    "시스템 알림",
+                    "시스템 공지",
+                    NotificationType.SYSTEM,
+                    "/system",
+                    LocalDateTime.now()
+            );
+
+            // when
+            webSocketService.broadcastSystemNotification(systemDto);
+
+            // then
+            verify(messagingTemplate).convertAndSend(
+                    eq(expectedDestination),
+                    eq(systemDto)
+            );
+        }
+
+        @Test
+        @DisplayName("브로드캐스트 실패 시 예외 로깅하고 정상 종료")
+        void t2() {
+            // given
+            willThrow(new RuntimeException("브로드캐스트 실패"))
+                    .given(messagingTemplate)
+                    .convertAndSend(anyString(), any(Object.class));
+
+            // when & then
+            webSocketService.broadcastSystemNotification(notificationDto);
+
+            verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("스터디룸 알림 전송 테스트")
+    class SendNotificationToRoomTest {
+
+        @Test
+        @DisplayName("스터디룸 멤버들에게 알림 전송")
+        void t1() {
+            // given
+            Long roomId = 100L;
+            String expectedDestination = "/topic/room/100/notifications";
+            NotificationWebSocketDto roomDto = NotificationWebSocketDto.from(
+                    3L,
+                    "스터디룸 알림",
+                    "새 공지사항",
+                    NotificationType.ROOM,
+                    "/room/100",
+                    LocalDateTime.now()
+            );
+
+            // when
+            webSocketService.sendNotificationToRoom(roomId, roomDto);
+
+            // then
+            verify(messagingTemplate).convertAndSend(
+                    eq(expectedDestination),
+                    eq(roomDto)
+            );
+        }
+
+        @Test
+        @DisplayName("전송 실패 시 예외 로깅하고 정상 종료")
+        void t2() {
+            // given
+            Long roomId = 100L;
+            willThrow(new RuntimeException("룸 전송 실패"))
+                    .given(messagingTemplate)
+                    .convertAndSend(anyString(), any(Object.class));
+
+            // when & then
+            webSocketService.sendNotificationToRoom(roomId, notificationDto);
+
+            verify(messagingTemplate).convertAndSend(anyString(), any(Object.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("destination 검증 테스트")
+    class DestinationTest {
+
+        @Test
+        @DisplayName("유저별 알림 경로 정상 생성")
+        void t1() {
+            // given
+            Long userId = 12345L;
+
+            // when
+            webSocketService.sendNotificationToUser(userId, notificationDto);
+
+            // then
+            verify(messagingTemplate).convertAndSend(
+                    eq("/topic/user/12345/notifications"),
+                    any(Object.class)
+            );
+        }
+
+        @Test
+        @DisplayName("스터디룸 알림 경로 정상 생성")
+        void t2() {
+            // given
+            Long roomId = 99L;
+
+            // when
+            webSocketService.sendNotificationToRoom(roomId, notificationDto);
+
+            // then
+            verify(messagingTemplate).convertAndSend(
+                    eq("/topic/room/99/notifications"),
+                    any(Object.class)
+            );
+        }
+
+        @Test
+        @DisplayName("시스템 알림 경로 정상 생성")
+        void t3() {
+            // when
+            webSocketService.broadcastSystemNotification(notificationDto);
+
+            // then
+            verify(messagingTemplate).convertAndSend(
+                    eq("/topic/notifications/system"),
+                    any(Object.class)
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 📌 개요
알림 시스템 와이어프레임 확인 후 발신자 정보 추가 및 전체 테스트 코드 작성

<br>

## 🔨 작업 내용
### 1. 엔티티 / DTO 수정
- **Notification 엔티티**
  - `User actor` 필드 추가 (발신자 정보)
  - `user` → `receiver` 변수명 변경 (수신자 명확화)
  - `status` 필드 제거 (NotificationRead로 읽음 관리 통일)
  - 모든 정적 팩토리 메서드에 `actor` 파라미터 추가
  
- **DTO 추가/수정**
  - `ActorDto` 공통 DTO 생성 (발신자 정보: userId, username, profileImageUrl)
  - 모든 응답 DTO에 `ActorDto` 추가
  - `NotificationCreateRequest`에 `actorId` 필드 추가

### 2. Repository 수정
- **NotificationRepositoryImpl**
  - 모든 쿼리에서 `notification.user` → `notification.receiver`로 변경
  - ROOM 알림 조회를 위해 RoomMember와 LEFT JOIN 추가

### 3. Service 수정
- **NotificationService**
  - 모든 알림 생성 메서드에 `actor` 파라미터 추가
  - `validateActorAndReceiver()` 검증 메서드 추가 (자기 자신에게 알림 방지)
  - `markAsRead()` 강화
    - 접근 권한 검증 (`isVisibleToUser`)
    - 이미 읽은 알림 체크 시 예외 발생 (`NOTIFICATION_ALREADY_READ`)

### 4. Controller 수정
- **NotificationController**
  - Request 검증 로직 추가
    - targetType 유효성 검증
    - SYSTEM이 아닌 경우 actorId, targetId 필수 검증

### 5. 테스트 코드 작성/수정
- `NotificationRepositoryTest` : 모든 알림 생성 시 actor 파라미터 추가, ROOM 알림 조회 테스트 통과 확인
- `NotificationServiceTest` : actor 추가, 자기 자신에게 알림 전송 시 예외 테스트 추가, 이미 읽은 알림 읽음 처리 시 예외 테스트 수정
- `NotificationWebSocketServiceTest` : NotificationWebSocketDto.from() 사용 방식 변경 (Notification 객체 전달)
- `NotificationControllerTest`  (신규)
<br>

## 🔗 관련 이슈
Closes #155
<br>


## 📝 참고 사항
### 주요 변경 이유
- **와이어프레임 요구사항** : "Patrick 님이 댓글을 달았습니다" 같은 발신자 정보 표시 필요
- **프론트엔드 활용** : actor 정보로 프로필 이미지, 이름 생성 가능
- **읽음 관리 통일** : status 필드 제거로 시스템 알림의 사용자별 읽음 상태 관리 일관성 확보

### 아키텍처 개선
- DTO 레이어 분리 원칙 준수 (ActorDto 사용)
- User 헬퍼 메서드(getNickname(), getProfileImageUrl()) 활용
- N+1 문제 방지 (UserProfile fetch 불필요)

### 주의사항
=> **프로그램 실행 전 Q클래스 재생성 필요 (`./gradlew clean compileJava`)**
<br>


## ✅ 체크리스트
- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화