### PR TITLE
Feat: 카테고리 데이터 및 조회/생성 API 구현 (#196)

### DIFF
--- a/src/main/java/com/back/domain/board/post/controller/PostCategoryController.java
+++ b/src/main/java/com/back/domain/board/post/controller/PostCategoryController.java
@@ -1,14 +1,16 @@
 package com.back.domain.board.post.controller;
 
+import com.back.domain.board.post.dto.CategoryRequest;
 import com.back.domain.board.post.dto.CategoryResponse;
 import com.back.domain.board.post.service.PostCategoryService;
 import com.back.global.common.dto.RsData;
+import com.back.global.security.user.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -17,6 +19,21 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostCategoryController {
     private final PostCategoryService postCategoryService;
+
+    // 카테고리 생성
+    @PostMapping
+    public ResponseEntity<RsData<CategoryResponse>> createCategory(
+            @RequestBody @Valid CategoryRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        CategoryResponse response = postCategoryService.createCategory(request, user.getUserId());
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(RsData.success(
+                        "카테고리가 생성되었습니다.",
+                        response
+                ));
+    }
 
     // 카테고리 전체 조회
     @GetMapping

--- a/src/main/java/com/back/domain/board/post/controller/PostCategoryController.java
+++ b/src/main/java/com/back/domain/board/post/controller/PostCategoryController.java
@@ -1,0 +1,32 @@
+package com.back.domain.board.post.controller;
+
+import com.back.domain.board.post.dto.CategoryResponse;
+import com.back.domain.board.post.service.PostCategoryService;
+import com.back.global.common.dto.RsData;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/posts/categories")
+@RequiredArgsConstructor
+public class PostCategoryController {
+    private final PostCategoryService postCategoryService;
+
+    // 카테고리 전체 조회
+    @GetMapping
+    public ResponseEntity<RsData<List<CategoryResponse>>> getAllCategories() {
+        List<CategoryResponse> response = postCategoryService.getAllCategories();
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success(
+                        "카테고리 목록이 조회되었습니다.",
+                        response
+                ));
+    }
+}

--- a/src/main/java/com/back/domain/board/post/controller/PostCategoryController.java
+++ b/src/main/java/com/back/domain/board/post/controller/PostCategoryController.java
@@ -17,7 +17,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/posts/categories")
 @RequiredArgsConstructor
-public class PostCategoryController {
+public class PostCategoryController implements PostCategoryControllerDocs {
     private final PostCategoryService postCategoryService;
 
     // 카테고리 생성

--- a/src/main/java/com/back/domain/board/post/controller/PostCategoryControllerDocs.java
+++ b/src/main/java/com/back/domain/board/post/controller/PostCategoryControllerDocs.java
@@ -1,0 +1,188 @@
+package com.back.domain.board.post.controller;
+
+import com.back.domain.board.post.dto.CategoryRequest;
+import com.back.domain.board.post.dto.CategoryResponse;
+import com.back.global.common.dto.RsData;
+import com.back.global.security.user.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@Tag(name = "Category API", description = "게시글 카테고리 관련 API")
+public interface PostCategoryControllerDocs {
+
+    @Operation(
+            summary = "카테고리 생성",
+            description = "로그인한 사용자가 새 카테고리를 등록합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "카테고리 생성 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_201",
+                                      "message": "카테고리가 생성되었습니다.",
+                                      "data": {
+                                        "id": 80,
+                                        "name": "수학 II",
+                                        "type": "SUBJECT"
+                                      }
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (필드 누락 등)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_400",
+                                      "message": "잘못된 요청입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패 (Access Token 없음/만료/잘못됨)",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "토큰 없음", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_001",
+                                              "message": "인증이 필요합니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "유효하지 않은 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_002",
+                                              "message": "유효하지 않은 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """),
+                                    @ExampleObject(name = "만료된 토큰", value = """
+                                            {
+                                              "success": false,
+                                              "code": "AUTH_004",
+                                              "message": "만료된 액세스 토큰입니다.",
+                                              "data": null
+                                            }
+                                            """)
+                            }
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "존재하지 않는 사용자",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "USER_001",
+                                      "message": "존재하지 않는 사용자입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 카테고리 이름",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "POST_004",
+                                      "message": "이미 존재하는 카테고리입니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<CategoryResponse>> createCategory(
+            @RequestBody CategoryRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "카테고리 전체 조회",
+            description = "현재 등록된 모든 카테고리 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "카테고리 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": true,
+                                      "code": "SUCCESS_200",
+                                      "message": "카테고리 목록이 조회되었습니다.",
+                                      "data": [
+                                        { "id": 1, "name": "프론트엔드", "type": "SUBJECT" },
+                                        { "id": 2, "name": "백엔드", "type": "SUBJECT" },
+                                        { "id": 3, "name": "CS", "type": "SUBJECT" },
+                                        { "id": 74, "name": "중학생", "type": "DEMOGRAPHIC" },
+                                        { "id": 78, "name": "2~4명", "type": "GROUP_SIZE" }
+                                      ]
+                                    }
+                                    """)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "success": false,
+                                      "code": "COMMON_500",
+                                      "message": "서버 오류가 발생했습니다.",
+                                      "data": null
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<RsData<List<CategoryResponse>>> getAllCategories();
+}

--- a/src/main/java/com/back/domain/board/post/dto/CategoryRequest.java
+++ b/src/main/java/com/back/domain/board/post/dto/CategoryRequest.java
@@ -1,0 +1,17 @@
+package com.back.domain.board.post.dto;
+
+import com.back.domain.board.post.enums.CategoryType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 카테고리 생성 요청 DTO
+ *
+ * @param name  카테고리 이름
+ * @param type  카테고리 분류
+ */
+public record CategoryRequest(
+        @NotBlank String name,
+        @NotNull CategoryType type
+) {
+}

--- a/src/main/java/com/back/domain/board/post/dto/CategoryResponse.java
+++ b/src/main/java/com/back/domain/board/post/dto/CategoryResponse.java
@@ -1,6 +1,7 @@
 package com.back.domain.board.post.dto;
 
 import com.back.domain.board.post.entity.PostCategory;
+import com.back.domain.board.post.enums.CategoryType;
 import com.querydsl.core.annotations.QueryProjection;
 
 /**
@@ -8,10 +9,12 @@ import com.querydsl.core.annotations.QueryProjection;
  *
  * @param id    카테고리 ID
  * @param name  카테고리 이름
+ * @param type  카테고리 분류
  */
 public record CategoryResponse(
         Long id,
-        String name
+        String name,
+        CategoryType type
 ) {
     @QueryProjection
     public CategoryResponse {}
@@ -19,7 +22,8 @@ public record CategoryResponse(
     public static CategoryResponse from(PostCategory category) {
         return new CategoryResponse(
                 category.getId(),
-                category.getName()
+                category.getName(),
+                category.getType()
         );
     }
 }

--- a/src/main/java/com/back/domain/board/post/entity/PostCategory.java
+++ b/src/main/java/com/back/domain/board/post/entity/PostCategory.java
@@ -1,9 +1,8 @@
 package com.back.domain.board.post.entity;
 
+import com.back.domain.board.post.enums.CategoryType;
 import com.back.global.entity.BaseEntity;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -15,6 +14,10 @@ import java.util.List;
 @Getter
 public class PostCategory extends BaseEntity {
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CategoryType type;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostCategoryMapping> postCategoryMappings;

--- a/src/main/java/com/back/domain/board/post/entity/PostCategory.java
+++ b/src/main/java/com/back/domain/board/post/entity/PostCategory.java
@@ -25,6 +25,13 @@ public class PostCategory extends BaseEntity {
     // -------------------- 생성자 --------------------
     public PostCategory(String name) {
         this.name = name;
+        this.type = CategoryType.SUBJECT;
+        this.postCategoryMappings = new ArrayList<>();
+    }
+
+    public PostCategory(String name, CategoryType type) {
+        this.name = name;
+        this.type = type;
         this.postCategoryMappings = new ArrayList<>();
     }
 }

--- a/src/main/java/com/back/domain/board/post/enums/CategoryType.java
+++ b/src/main/java/com/back/domain/board/post/enums/CategoryType.java
@@ -1,0 +1,7 @@
+package com.back.domain.board.post.enums;
+
+public enum CategoryType {
+    SUBJECT,     // 과목
+    DEMOGRAPHIC, // 연령대
+    GROUP_SIZE   // 인원
+}

--- a/src/main/java/com/back/domain/board/post/repository/PostCategoryRepository.java
+++ b/src/main/java/com/back/domain/board/post/repository/PostCategoryRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostCategoryRepository extends JpaRepository<PostCategory, Long> {
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/back/domain/board/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/back/domain/board/post/repository/PostRepositoryImpl.java
@@ -198,7 +198,11 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         List<Tuple> categoryTuples = queryFactory
                 .select(
                         categoryMapping.post.id,
-                        new QCategoryResponse(categoryMapping.category.id, categoryMapping.category.name)
+                        new QCategoryResponse(
+                                categoryMapping.category.id,
+                                categoryMapping.category.name,
+                                categoryMapping.category.type
+                        )
                 )
                 .from(categoryMapping)
                 .where(categoryMapping.post.id.in(postIds))

--- a/src/main/java/com/back/domain/board/post/service/PostCategoryService.java
+++ b/src/main/java/com/back/domain/board/post/service/PostCategoryService.java
@@ -1,0 +1,28 @@
+package com.back.domain.board.post.service;
+
+import com.back.domain.board.post.dto.CategoryResponse;
+import com.back.domain.board.post.repository.PostCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostCategoryService {
+    private final PostCategoryRepository postCategoryRepository;
+
+    /**
+     * 카테고리 전체 조회 서비스
+     * 1. PostCategory 전체 조회
+     * 2. List<CategoryResponse> 반환
+     */
+    public List<CategoryResponse> getAllCategories() {
+        return postCategoryRepository.findAll()
+                .stream()
+                .map(CategoryResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/back/domain/board/post/service/PostCategoryService.java
+++ b/src/main/java/com/back/domain/board/post/service/PostCategoryService.java
@@ -1,7 +1,13 @@
 package com.back.domain.board.post.service;
 
+import com.back.domain.board.post.dto.CategoryRequest;
 import com.back.domain.board.post.dto.CategoryResponse;
+import com.back.domain.board.post.entity.PostCategory;
 import com.back.domain.board.post.repository.PostCategoryRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.exception.CustomException;
+import com.back.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,12 +19,40 @@ import java.util.List;
 @Transactional
 public class PostCategoryService {
     private final PostCategoryRepository postCategoryRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 카테고리 생성 서비스
+     * 1. User 조회
+     * 2. 이미 존재하는 경우 예외
+     * 3. PostCategory 생성
+     * 4. PostCategory 저장 및 CategoryResponse 반환
+     */
+    public CategoryResponse createCategory(CategoryRequest request, Long userId) {
+
+        // User 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 존재하는 카테고리인 경우 예외 처리
+        if (postCategoryRepository.existsByName(request.name())) {
+            throw new CustomException(ErrorCode.CATEGORY_ALREADY_EXISTS);
+        }
+
+        // PostCategory 생성
+        PostCategory category = new PostCategory(request.name(), request.type());
+
+        // PostCategory 저장 및 응답 반환
+        PostCategory saved = postCategoryRepository.save(category);
+        return CategoryResponse.from(saved);
+    }
 
     /**
      * 카테고리 전체 조회 서비스
      * 1. PostCategory 전체 조회
      * 2. List<CategoryResponse> 반환
      */
+    @Transactional(readOnly = true)
     public List<CategoryResponse> getAllCategories() {
         return postCategoryRepository.findAll()
                 .stream()

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -96,7 +96,7 @@ public enum ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_001", "존재하지 않는 게시글입니다."),
     POST_NO_PERMISSION(HttpStatus.FORBIDDEN, "POST_002", "게시글 작성자만 수정/삭제할 수 있습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_003", "존재하지 않는 카테고리입니다."),
-    CATEGORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "POST_004", "이미 존재하는 카테고리입니다."),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "POST_004", "이미 존재하는 카테고리입니다."),
 
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "존재하지 않는 댓글입니다."),
     COMMENT_NO_PERMISSION(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글 작성자만 수정/삭제할 수 있습니다."),

--- a/src/main/java/com/back/global/exception/ErrorCode.java
+++ b/src/main/java/com/back/global/exception/ErrorCode.java
@@ -96,6 +96,8 @@ public enum ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_001", "존재하지 않는 게시글입니다."),
     POST_NO_PERMISSION(HttpStatus.FORBIDDEN, "POST_002", "게시글 작성자만 수정/삭제할 수 있습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "POST_003", "존재하지 않는 카테고리입니다."),
+    CATEGORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "POST_004", "이미 존재하는 카테고리입니다."),
+
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "존재하지 않는 댓글입니다."),
     COMMENT_NO_PERMISSION(HttpStatus.FORBIDDEN, "COMMENT_002", "댓글 작성자만 수정/삭제할 수 있습니다."),
     COMMENT_PARENT_MISMATCH(HttpStatus.BAD_REQUEST, "COMMENT_003", "부모 댓글이 해당 게시글에 속하지 않습니다."),

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,6 +23,11 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+    defer-datasource-initialization: true
+
+  sql:
+    init:
+      mode: always
 
   security:
     oauth2:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -10,6 +10,10 @@ spring:
       host: ${SPRING_REDIS_HOST:localhost}
       port: ${SPRING_REDIS_PORT:6379}
 
+  sql:
+    init:
+      mode: never
+
   security:
     oauth2:
       client:

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,96 @@
+-- =========================
+-- SUBJECT 카테고리
+-- =========================
+INSERT INTO post_category (name, type, created_at, updated_at)
+VALUES
+    ('프론트엔드', 'SUBJECT', NOW(), NOW()),
+    ('백엔드', 'SUBJECT', NOW(), NOW()),
+    ('CS', 'SUBJECT', NOW(), NOW()),
+    ('알고리즘', 'SUBJECT', NOW(), NOW()),
+    ('데이터 사이언스', 'SUBJECT', NOW(), NOW()),
+    ('인공지능', 'SUBJECT', NOW(), NOW()),
+    ('클라우드', 'SUBJECT', NOW(), NOW()),
+    ('보안', 'SUBJECT', NOW(), NOW()),
+    ('데브옵스', 'SUBJECT', NOW(), NOW()),
+    ('영어', 'SUBJECT', NOW(), NOW()),
+    ('영어 회화', 'SUBJECT', NOW(), NOW()),
+    ('토익', 'SUBJECT', NOW(), NOW()),
+    ('토플', 'SUBJECT', NOW(), NOW()),
+    ('아이엘츠', 'SUBJECT', NOW(), NOW()),
+    ('일본어', 'SUBJECT', NOW(), NOW()),
+    ('JLPT', 'SUBJECT', NOW(), NOW()),
+    ('중국어', 'SUBJECT', NOW(), NOW()),
+    ('HSK', 'SUBJECT', NOW(), NOW()),
+    ('스페인어', 'SUBJECT', NOW(), NOW()),
+    ('프랑스어', 'SUBJECT', NOW(), NOW()),
+    ('독일어', 'SUBJECT', NOW(), NOW()),
+    ('수학', 'SUBJECT', NOW(), NOW()),
+    ('확률통계', 'SUBJECT', NOW(), NOW()),
+    ('물리', 'SUBJECT', NOW(), NOW()),
+    ('화학', 'SUBJECT', NOW(), NOW()),
+    ('생명과학', 'SUBJECT', NOW(), NOW()),
+    ('천문', 'SUBJECT', NOW(), NOW()),
+    ('역사', 'SUBJECT', NOW(), NOW()),
+    ('철학', 'SUBJECT', NOW(), NOW()),
+    ('심리학', 'SUBJECT', NOW(), NOW()),
+    ('사회', 'SUBJECT', NOW(), NOW()),
+    ('경제', 'SUBJECT', NOW(), NOW()),
+    ('글쓰기', 'SUBJECT', NOW(), NOW()),
+    ('에세이', 'SUBJECT', NOW(), NOW()),
+    ('독서', 'SUBJECT', NOW(), NOW()),
+    ('속독', 'SUBJECT', NOW(), NOW()),
+    ('프레젠테이션', 'SUBJECT', NOW(), NOW()),
+    ('스피치', 'SUBJECT', NOW(), NOW()),
+    ('논술', 'SUBJECT', NOW(), NOW()),
+    ('자기계발', 'SUBJECT', NOW(), NOW()),
+    ('음악이론', 'SUBJECT', NOW(), NOW()),
+    ('피아노', 'SUBJECT', NOW(), NOW()),
+    ('기타', 'SUBJECT', NOW(), NOW()),
+    ('드로잉', 'SUBJECT', NOW(), NOW()),
+    ('수채화', 'SUBJECT', NOW(), NOW()),
+    ('디지털아트', 'SUBJECT', NOW(), NOW()),
+    ('사진', 'SUBJECT', NOW(), NOW()),
+    ('영상편집', 'SUBJECT', NOW(), NOW()),
+    ('요리', 'SUBJECT', NOW(), NOW()),
+    ('제과제빵', 'SUBJECT', NOW(), NOW()),
+    ('바리스타', 'SUBJECT', NOW(), NOW()),
+    ('정보처리기사', 'SUBJECT', NOW(), NOW()),
+    ('컴활', 'SUBJECT', NOW(), NOW()),
+    ('MOS', 'SUBJECT', NOW(), NOW()),
+    ('한국사능력검정', 'SUBJECT', NOW(), NOW()),
+    ('교원임용', 'SUBJECT', NOW(), NOW()),
+    ('회계관리', 'SUBJECT', NOW(), NOW()),
+    ('전산회계', 'SUBJECT', NOW(), NOW()),
+    ('GTQ', 'SUBJECT', NOW(), NOW()),
+    ('마케팅', 'SUBJECT', NOW(), NOW()),
+    ('브랜딩', 'SUBJECT', NOW(), NOW()),
+    ('서비스기획', 'SUBJECT', NOW(), NOW()),
+    ('UX/UI', 'SUBJECT', NOW(), NOW()),
+    ('제품디자인', 'SUBJECT', NOW(), NOW()),
+    ('재테크', 'SUBJECT', NOW(), NOW()),
+    ('부동산', 'SUBJECT', NOW(), NOW()),
+    ('주식', 'SUBJECT', NOW(), NOW()),
+    ('코칭', 'SUBJECT', NOW(), NOW()),
+    ('명상', 'SUBJECT', NOW(), NOW()),
+    ('기타 과목', 'SUBJECT', NOW(), NOW());
+
+-- =========================
+-- DEMOGRAPHIC 카테고리
+-- =========================
+INSERT INTO post_category (name, type, created_at, updated_at)
+VALUES
+    ('중학생', 'DEMOGRAPHIC', NOW(), NOW()),
+    ('고등학생', 'DEMOGRAPHIC', NOW(), NOW()),
+    ('대학생', 'DEMOGRAPHIC', NOW(), NOW()),
+    ('취준생', 'DEMOGRAPHIC', NOW(), NOW()),
+    ('직장인', 'DEMOGRAPHIC', NOW(), NOW()),
+    ('기타', 'DEMOGRAPHIC', NOW(), NOW());
+
+-- =========================
+-- GROUP_SIZE 카테고리
+-- =========================
+INSERT INTO post_category (name, type, created_at, updated_at)
+VALUES
+    ('2~4명', 'GROUP_SIZE', NOW(), NOW()),
+    ('5~10명', 'GROUP_SIZE', NOW(), NOW()),
+    ('10~20명', 'GROUP_SIZE', NOW(), NOW());

--- a/src/test/java/com/back/domain/board/controller/PostCategoryControllerTest.java
+++ b/src/test/java/com/back/domain/board/controller/PostCategoryControllerTest.java
@@ -1,0 +1,210 @@
+package com.back.domain.board.controller;
+
+import com.back.domain.board.post.dto.CategoryRequest;
+import com.back.domain.board.post.enums.CategoryType;
+import com.back.domain.board.post.entity.PostCategory;
+import com.back.domain.board.post.repository.PostCategoryRepository;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserProfile;
+import com.back.domain.user.entity.UserStatus;
+import com.back.domain.user.repository.UserRepository;
+import com.back.fixture.TestJwtTokenProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class PostCategoryControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostCategoryRepository postCategoryRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private TestJwtTokenProvider testJwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private String generateAccessToken(User user) {
+        return testJwtTokenProvider.createAccessToken(user.getId(), user.getUsername(), user.getRole().name());
+    }
+
+    // ====================== 카테고리 생성 테스트 ======================
+
+    @Test
+    @DisplayName("카테고리 생성 성공 → 201 Created")
+    void createCategory_success() throws Exception {
+        // given: 로그인 사용자
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "홍길동", null, "소개글", LocalDate.of(2000, 1, 1), 1000));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        String accessToken = generateAccessToken(user);
+
+        CategoryRequest request = new CategoryRequest("수학 II", CategoryType.SUBJECT);
+
+        // when
+        ResultActions resultActions = mvc.perform(post("/api/posts/categories")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("SUCCESS_200"))
+                .andExpect(jsonPath("$.data.name").value("수학 II"))
+                .andExpect(jsonPath("$.data.type").value("SUBJECT"));
+
+        // DB 확인
+        assertThat(postCategoryRepository.existsByName("수학 II")).isTrue();
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 존재하지 않는 사용자 → 404 Not Found")
+    void createCategory_userNotFound() throws Exception {
+        // given: 토큰만 존재 (DB엔 유저 없음)
+        String fakeToken = testJwtTokenProvider.createAccessToken(999L, "ghost", "USER");
+        CategoryRequest request = new CategoryRequest("영어", CategoryType.SUBJECT);
+
+        // when & then
+        mvc.perform(post("/api/posts/categories")
+                        .header("Authorization", "Bearer " + fakeToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_001"))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 이미 존재하는 카테고리 → 409 Conflict")
+    void createCategory_conflict() throws Exception {
+        // given
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserProfile(new UserProfile(user, "작성자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        String accessToken = generateAccessToken(user);
+
+        // 기존 카테고리 저장
+        postCategoryRepository.save(new PostCategory("CS", CategoryType.SUBJECT));
+
+        CategoryRequest request = new CategoryRequest("CS", CategoryType.SUBJECT);
+
+        // when & then
+        mvc.perform(post("/api/posts/categories")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("POST_004"))
+                .andExpect(jsonPath("$.message").value("이미 존재하는 카테고리입니다."));
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 요청 필드 누락 → 400 Bad Request")
+    void createCategory_badRequest() throws Exception {
+        // given: 로그인 유저
+        User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        String accessToken = generateAccessToken(user);
+
+        // name 누락
+        String invalidJson = """
+                {
+                  "type": "SUBJECT"
+                }
+                """;
+
+        // when & then
+        mvc.perform(post("/api/posts/categories")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidJson))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("COMMON_400"))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 토큰 없음 → 401 Unauthorized")
+    void createCategory_noToken() throws Exception {
+        // given
+        CategoryRequest request = new CategoryRequest("프론트엔드", CategoryType.SUBJECT);
+
+        // when & then
+        mvc.perform(post("/api/posts/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_001"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+    // ====================== 카테고리 전체 조회 테스트 ======================
+
+    @Test
+    @DisplayName("카테고리 전체 조회 성공 → 200 OK")
+    void getAllCategories_success() throws Exception {
+        // given
+        postCategoryRepository.saveAll(List.of(
+                new PostCategory("백엔드", CategoryType.SUBJECT),
+                new PostCategory("중학생", CategoryType.DEMOGRAPHIC),
+                new PostCategory("2~4명", CategoryType.GROUP_SIZE)
+        ));
+
+        // when
+        ResultActions resultActions = mvc.perform(get("/api/posts/categories")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value("SUCCESS_200"))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].name").exists())
+                .andExpect(jsonPath("$.data[0].type").exists());
+    }
+}

--- a/src/test/java/com/back/domain/board/service/PostCategoryServiceTest.java
+++ b/src/test/java/com/back/domain/board/service/PostCategoryServiceTest.java
@@ -1,0 +1,113 @@
+package com.back.domain.board.service;
+
+import com.back.domain.board.post.dto.CategoryRequest;
+import com.back.domain.board.post.dto.CategoryResponse;
+import com.back.domain.board.post.enums.CategoryType;
+import com.back.domain.board.post.entity.PostCategory;
+import com.back.domain.board.post.repository.PostCategoryRepository;
+import com.back.domain.board.post.service.PostCategoryService;
+import com.back.domain.user.entity.User;
+import com.back.domain.user.entity.UserProfile;
+import com.back.domain.user.entity.UserStatus;
+import com.back.domain.user.repository.UserRepository;
+import com.back.global.exception.CustomException;
+import com.back.global.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class PostCategoryServiceTest {
+
+    @Autowired
+    private PostCategoryService postCategoryService;
+
+    @Autowired
+    private PostCategoryRepository postCategoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    // ====================== 카테고리 생성 테스트 ======================
+
+    @Test
+    @DisplayName("카테고리 생성 성공")
+    void createCategory_success() {
+        // given
+        User user = User.createUser("writer", "writer@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "작성자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        CategoryRequest request = new CategoryRequest("백엔드", CategoryType.SUBJECT);
+
+        // when
+        CategoryResponse response = postCategoryService.createCategory(request, user.getId());
+
+        // then
+        assertThat(response.name()).isEqualTo("백엔드");
+        assertThat(response.type()).isEqualTo(CategoryType.SUBJECT);
+        assertThat(postCategoryRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 존재하지 않는 유저")
+    void createCategory_fail_userNotFound() {
+        // given
+        CategoryRequest request = new CategoryRequest("프론트엔드", CategoryType.SUBJECT);
+
+        // when & then
+        assertThatThrownBy(() -> postCategoryService.createCategory(request, 999L))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("카테고리 생성 실패 - 이미 존재하는 카테고리 이름")
+    void createCategory_fail_alreadyExists() {
+        // given
+        User user = User.createUser("admin", "admin@example.com", "encodedPwd");
+        user.setUserProfile(new UserProfile(user, "관리자", null, null, null, 0));
+        user.setUserStatus(UserStatus.ACTIVE);
+        userRepository.save(user);
+
+        // 같은 이름의 카테고리 미리 저장
+        postCategoryRepository.save(new PostCategory("CS", CategoryType.SUBJECT));
+
+        CategoryRequest request = new CategoryRequest("CS", CategoryType.SUBJECT);
+
+        // when & then
+        assertThatThrownBy(() -> postCategoryService.createCategory(request, user.getId()))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.CATEGORY_ALREADY_EXISTS.getMessage());
+    }
+
+    // ====================== 카테고리 조회 테스트 ======================
+
+    @Test
+    @DisplayName("카테고리 전체 조회 성공")
+    void getAllCategories_success() {
+        // given
+        postCategoryRepository.save(new PostCategory("백엔드", CategoryType.SUBJECT));
+        postCategoryRepository.save(new PostCategory("중학생", CategoryType.DEMOGRAPHIC));
+        postCategoryRepository.save(new PostCategory("2~4명", CategoryType.GROUP_SIZE));
+
+        // when
+        List<CategoryResponse> responses = postCategoryService.getAllCategories();
+
+        // then
+        assertThat(responses).hasSize(3);
+        assertThat(responses)
+                .extracting(CategoryResponse::name)
+                .containsExactlyInAnyOrder("백엔드", "중학생", "2~4명");
+    }
+}


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 게시글 카테고리(`PostCategory`) 관련 기능을 추가했습니다.
- 엔티티 구조 수정, 초기 데이터 설정, 조회/생성 API 구현, Swagger 문서 및 테스트를 포함합니다.

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

#### 1. 엔티티 수정

* `PostCategory`에 `CategoryType`(enum) 필드 추가
* `CategoryType`: `SUBJECT`, `DEMOGRAPHIC`, `GROUP_SIZE`
* 생성자 오버로드(`name`, `name + type`)

#### 2. 초기 데이터 설정

* `data.sql`을 통해 90여 개의 기본 카테고리 자동 등록
* `application-dev.yml`에서 `defer-datasource-initialization: true`, `sql.init.mode: always` 설정

#### 3. API 구현

* **카테고리 전체 조회 (GET /api/posts/categories)**
  * 모든 카테고리 반환
  * `CategoryResponse`에 `type` 필드 포함

* **카테고리 생성 (POST /api/posts/categories)**
  * 로그인 사용자만 등록 가능
  * 중복 시 `409 Conflict`, 존재하지 않는 사용자 시 `404 Not Found` 처리

#### 4. 예외 코드 추가

| 코드         | 상태  | 메시지              |
| ---------- | --- | ---------------- |
| `POST_003` | 404 | 존재하지 않는 카테고리입니다. |
| `POST_004` | 409 | 이미 존재하는 카테고리입니다. |

#### 5. Swagger 문서

* `PostCategoryControllerDocs` 인터페이스 작성
* 요청/응답 예시 및 에러 코드 상세 기술

#### 6. 테스트

* **Service 단위 테스트**: 생성 성공/실패, 전체 조회
* **Controller 통합 테스트**: JWT 인증 포함, 성공 및 예외 케이스 검증

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #196

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

* `PostCategory`에 `type` 필드 추가 -> 노션 ERD 페이지에 추가해두었습니다.
* 개발 환경에서는 `data.sql`이 자동 실행되어 기본 카테고리가 등록됩니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
