### PR TITLE
Refactor: PostCategoryMapping Unique Key 충돌 문제 해결 (#245)

### DIFF
--- a/src/main/java/com/back/domain/board/post/entity/Post.java
+++ b/src/main/java/com/back/domain/board/post/entity/Post.java
@@ -62,6 +62,10 @@ public class Post extends BaseEntity {
         this.postCategoryMappings.add(mapping);
     }
 
+    public void removePostCategoryMapping(PostCategoryMapping mapping) {
+        this.postCategoryMappings.remove(mapping);
+    }
+
     public void addLike(PostLike like) {
         this.postLikes.add(like);
     }
@@ -93,11 +97,23 @@ public class Post extends BaseEntity {
         this.content = content;
     }
 
-    // TODO: 진짜로 바뀐 카테고리만 추가/삭제하도록 개선
     /** 카테고리 일괄 업데이트 */
-    public void updateCategories(List<PostCategory> categories) {
-        this.postCategoryMappings.clear();
-        categories.forEach(category -> new PostCategoryMapping(this, category));
+    public void updateCategories(List<PostCategory> newCategories) {
+        List<PostCategory> currentCategories = this.getCategories();
+
+        // 제거 대상
+        List<PostCategoryMapping> toRemove = this.getPostCategoryMappings().stream()
+                .filter(mapping -> !newCategories.contains(mapping.getCategory()))
+                .toList();
+
+        // 추가 대상
+        List<PostCategory> toAdd = newCategories.stream()
+                .filter(category -> !currentCategories.contains(category))
+                .toList();
+
+        // 실행
+        toRemove.forEach(this::removePostCategoryMapping);
+        toAdd.forEach(category -> new PostCategoryMapping(this, category));
     }
 
     /** 좋아요 수 증가 */

--- a/src/main/java/com/back/domain/board/post/service/PostService.java
+++ b/src/main/java/com/back/domain/board/post/service/PostService.java
@@ -49,17 +49,18 @@ public class PostService {
         // Post 생성
         Post post = new Post(user, request.title(), request.content(), request.thumbnailUrl());
 
+        // Post 저장
+        Post saved = postRepository.save(post);
+
         // Category 매핑
         if (request.categoryIds() != null) {
             List<PostCategory> categories = postCategoryRepository.findAllById(request.categoryIds());
             if (categories.size() != request.categoryIds().size()) {
                 throw new CustomException(ErrorCode.CATEGORY_NOT_FOUND);
             }
-            post.updateCategories(categories);
+            saved.updateCategories(categories);
         }
 
-        // Post 저장 및 응답 반환
-        Post saved = postRepository.save(post);
         return PostResponse.from(saved);
     }
 


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 게시글 수정 및 생성 시 발생하던 **Unique Key 충돌 및 flush 타이밍 문제**를 해결했습니다.
- 카테고리 매핑 시 `postCategoryMappings`를 즉시 초기화하면서 영속성 컨텍스트 내 동일 키 중복이 발생하던 부분을 개선했습니다.

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 1. `Post.updateCategories()` 로직 개선

* 기존: `postCategoryMappings.clear()` 후 전부 새로 추가
  → 기존 매핑이 삭제되지 않은 상태에서 동일한 `(post_id, category_id)` 조합이 중복으로 flush되며 Unique Key 충돌 발생

* 개선:
  * 현재 매핑과 새 매핑을 비교하여 **실제 변경된 카테고리만 추가/삭제**
  * 삭제는 `removePostCategoryMapping()`으로 안전하게 detach
  * 추가는 새 `PostCategoryMapping(this, category)` 생성으로 처리

### 2. `PostService.createPost()` 저장 순서 수정

* 기존: `Post` 생성 후 카테고리 매핑 후 저장

* 개선: **Post를 먼저 save**하여 영속 상태를 보장한 뒤, 카테고리 매핑 수행
  → flush 타이밍이 안정화되고, 비영속 상태에서 발생하던 key 충돌 방지

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #{이슈 번호}

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

-

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
