### PR TITLE
Fix: 게시글 이미지 첨부 오류 해결 (#308)

### DIFF
--- a/src/main/java/com/back/domain/board/post/entity/Post.java
+++ b/src/main/java/com/back/domain/board/post/entity/Post.java
@@ -92,9 +92,10 @@ public class Post extends BaseEntity {
 
     // -------------------- 비즈니스 메서드 --------------------
     /** 게시글 내용 수정 */
-    public void update(String title, String content) {
+    public void update(String title, String content, String thumbnailUrl) {
         this.title = title;
         this.content = content;
+        this.thumbnailUrl = thumbnailUrl;
     }
 
     /** 카테고리 일괄 업데이트 */


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->

- 게시글 수정 시 이미지 변경이 없더라도 기존 첨부 매핑이 모두 삭제되는 문제를 수정했습니다.
- 이제 기존 이미지가 그대로 유지되며, 변경이 있는 경우에만 S3 및 매핑이 갱신됩니다

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

* `updatePostAttachments()` 메서드 추가

  * 기존/새 첨부 이미지 비교 후 변경 여부에 따라 처리 분기
  * 변경 없음 → 기존 매핑 유지
  * 변경 있음 → 기존 파일 및 매핑 삭제 후 새 매핑 등록
* `deletePostAttachments()` 메서드 추가

  * 게시글 첨부 파일 및 매핑 삭제 로직 분리
* `validateAndFindCategories()` 및 `validateAndFindAttachments()` 메서드에 null/빈 리스트 방어 로직 추가

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #308

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->

- 추후 리팩토링 예정

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 작성
- [ ] 문서/주석 추가 및 최신화
