### PR TITLE
Feat: Presigned URL 기반 파일 업로드 방식 도입 (#324)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,9 +77,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("com.github.codemonstur:embedded-redis:1.4.3")
 
-    // AWS S3
+    // AWS
     implementation ("org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE")
-
+    implementation("software.amazon.awssdk:s3:2.40.4")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/domain/file/controller/FileController.java
+++ b/src/main/java/com/back/domain/file/controller/FileController.java
@@ -1,12 +1,12 @@
 package com.back.domain.file.controller;
 
 import com.back.domain.file.dto.*;
-import com.back.domain.file.entity.EntityType;
 import com.back.domain.file.service.FileService;
 import com.back.global.common.dto.RsData;
 import com.back.global.security.user.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -19,10 +19,18 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RequestMapping("/api/file")
 @Validated
+@Tag(
+        name =  "파일 관리 API",
+        description = "MultipartFile 기반 파일 업로드, 조회, 업데이트, 삭제 기능을 제공"
+)
 public class FileController {
     private final FileService fileService;
 
     @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "파일 업로드",
+            description = "MultipartFile을 업로드하고, 저장된 파일의 식별자(attachmentId)와 Public URL을 반환합니다."
+    )
     public ResponseEntity<RsData<FileUploadResponseDto>> uploadFile(
             @ModelAttribute @Valid FileUploadRequestDto req,
             @AuthenticationPrincipal CustomUserDetails user
@@ -38,6 +46,10 @@ public class FileController {
     }
 
     @GetMapping(value = "/read/{attachmentId}")
+    @Operation(
+            summary = "파일 정보 조회",
+            description = "attachmentId를 이용해 저장된 파일 정보를 조회하고, 해당 파일의 Public URL을 반환합니다."
+    )
     public ResponseEntity<RsData<FileReadResponseDto>> getFile(
             @PathVariable("attachmentId") Long attachmentId
     ) {
@@ -48,7 +60,12 @@ public class FileController {
                 .body(RsData.success("파일 조회 성공", res));
     }
 
+
     @PutMapping(value = "/update/{attachmentId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            summary = "파일 업데이트",
+            description = "기존 attachmentId에 연결된 파일을 새로운 MultipartFile로 교체하고, 변경된 파일의 Public URL을 반환합니다."
+    )
     public ResponseEntity<RsData<FileUpdateResponseDto>> updateFile(
             @PathVariable("attachmentId") Long attachmentId,
             @ModelAttribute @Valid FileUpdateRequestDto req,
@@ -66,6 +83,10 @@ public class FileController {
     }
 
     @DeleteMapping(value = "/delete/{attachmentId}")
+    @Operation(
+            summary = "파일 삭제",
+            description = "attachmentId에 해당하는 파일을 삭제합니다."
+    )
     public ResponseEntity<RsData<Void>> deleteFile(
             @PathVariable("attachmentId") Long attachmentId,
             @AuthenticationPrincipal CustomUserDetails user

--- a/src/main/java/com/back/domain/file/controller/PresignedUrlController.java
+++ b/src/main/java/com/back/domain/file/controller/PresignedUrlController.java
@@ -1,0 +1,18 @@
+package com.back.domain.file.controller;
+
+import com.back.domain.file.dto.PresignedUrlResponseDto;
+import com.back.global.common.dto.RsData;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/file")
+public class PresignedController {
+
+    public ResponseEntity<RsData<PresignedUrlResponseDto>> getPresignedUploadUrl(
+          @RequestParam String folder,
+          @RequestParam String fileName
+    ) {
+        String presignedUrl =
+    }
+}

--- a/src/main/java/com/back/domain/file/controller/PresignedUrlController.java
+++ b/src/main/java/com/back/domain/file/controller/PresignedUrlController.java
@@ -1,18 +1,60 @@
 package com.back.domain.file.controller;
 
 import com.back.domain.file.dto.PresignedUrlResponseDto;
+import com.back.domain.file.service.PresignedUrlService;
 import com.back.global.common.dto.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/file")
-public class PresignedController {
+@RequiredArgsConstructor
+@Tag(
+        name = "Presigned URL API",
+        description = "S3 업로드용 Presigned URL 발급 및 S3 객체 삭제 API"
+)
+public class PresignedUrlController {
+    private final PresignedUrlService presignedUrlService;
 
+    /**
+     * 업로드용 Presigned URL 발급 (대용량 업데이트 용)
+     */
+    @GetMapping("/presigned-upload")
+    @Operation(
+            summary = "S3 업로드용 Presigned URL 발급",
+            description = "S3 Direct Upload를 위해 Presigned URL과 업로드 대상 객체 정보를 반환합니다."
+    )
     public ResponseEntity<RsData<PresignedUrlResponseDto>> getPresignedUploadUrl(
-          @RequestParam String folder,
-          @RequestParam String fileName
+            @RequestParam String folder,
+            @RequestParam String fileName
     ) {
-        String presignedUrl =
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(RsData.success(
+                        "URL 발급 성공", presignedUrlService.generateUploadPresignedUrl(
+                                folder,
+                                fileName
+                        )
+                ));
+    }
+
+    /**
+     * objectURL 을 통해 S3 객체 삭제
+     */
+    @DeleteMapping
+    @Operation(
+            summary = "S3 객체 삭제",
+            description = "objectUrl에서 key를 추출하여 해당 S3 객체를 삭제합니다."
+    )
+    public ResponseEntity<RsData<Void>> deleteImage(@RequestParam String objectUrl) {
+        presignedUrlService.deleteFile(objectUrl);
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(RsData.success("S3 오브젝트 삭제 성공"));
     }
 }

--- a/src/main/java/com/back/domain/file/dto/PresignedUrlResponseDto.java
+++ b/src/main/java/com/back/domain/file/dto/PresignedUrlResponseDto.java
@@ -1,0 +1,2 @@
+package com.back.domain.file.dto;public class PresignedUrlResponseDto {
+}

--- a/src/main/java/com/back/domain/file/dto/PresignedUrlResponseDto.java
+++ b/src/main/java/com/back/domain/file/dto/PresignedUrlResponseDto.java
@@ -1,2 +1,14 @@
-package com.back.domain.file.dto;public class PresignedUrlResponseDto {
+package com.back.domain.file.dto;
+
+import lombok.Data;
+
+@Data
+public class PresignedUrlResponseDto {
+    private String uploadUrl;
+    private String objectUrl;
+
+    public PresignedUrlResponseDto(String uploadUrl, String objectUrl) {
+        this.uploadUrl = uploadUrl;
+        this.objectUrl = objectUrl;
+    }
 }

--- a/src/main/java/com/back/domain/file/service/PresignedUrlService.java
+++ b/src/main/java/com/back/domain/file/service/PresignedUrlService.java
@@ -1,4 +1,4 @@
-package com.back.domain.file.controller;
+package com.back.domain.file.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;

--- a/src/main/java/com/back/domain/file/service/PresignedUrlService.java
+++ b/src/main/java/com/back/domain/file/service/PresignedUrlService.java
@@ -1,0 +1,66 @@
+package com.back.domain.file.controller;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.back.domain.file.dto.PresignedUrlResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PresignedUrlService {
+    private final S3Presigner s3Presigner;
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public PresignedUrlResponseDto generateUploadPresignedUrl(String folder, String originalFileName) {
+        String key = folder + "/" + UUID.randomUUID() + "-" + originalFileName;
+
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType("image/jpeg")
+                .build();
+
+        // Presigned URL 발급 요청
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(
+                request -> request.putObjectRequest(objectRequest)
+                        .signatureDuration(Duration.ofMinutes(5L))
+        );
+
+        String objectUrl = String.format(
+                "https://%s.s3.%s.amazonaws.com/%s",
+                bucket,
+                region,
+                key
+        );
+
+        return new PresignedUrlResponseDto(presignedRequest.url().toString(), objectUrl);
+    }
+
+    public void deleteFile(String objectUrl) {
+        String key = extractKeyFromUrl(objectUrl);
+        amazonS3.deleteObject(new DeleteObjectRequest(bucket, key));
+    }
+
+    /** S3 URL -> Key을 반환하는 함수
+     * https://bucket.s3.amazonaws.com/images/test.jpg -> images/test.jpg
+    **/
+    private String extractKeyFromUrl(String url) {
+        int idx = url.indexOf(".amazonaws.com/") + ".amazonaws.com/".length();
+        return url.substring(idx);
+    }
+}

--- a/src/main/java/com/back/global/config/S3Config.java
+++ b/src/main/java/com/back/global/config/S3Config.java
@@ -7,6 +7,11 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -26,5 +31,20 @@ public class S3Config {
                 .withRegion(region)
                 .withCredentials(new AWSStaticCredentialsProvider(awsCred))
                 .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        S3Presigner.Builder builder = S3Presigner.builder().region(Region.of(region));
+
+        if(!accessKey.isEmpty() && !secretKey.isEmpty()) {
+            builder.credentialsProvider(StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKey, secretKey)
+            ));
+        } else {
+            builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -76,8 +76,8 @@ public class SecurityConfig {
                                 // 커뮤니티 관련
                                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
 
-                                // 파일 관련 (테스트용, 추후 요청 제한 예정)
-                                .requestMatchers("/file/**").permitAll()
+                                // 파일 관련 (테스트 용)
+//                                .requestMatchers("api/file/**").permitAll()
 
                                 // 그 외 모든 요청은 인증 필요
                                 .anyRequest().authenticated()

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -75,8 +75,8 @@ spring:
             user-name-attribute: id
   servlet:
     multipart:
-      max-file-size: 10MB # 업로드할 수 있는 개별 파일의 최대 크기
-      max-request-size: 10MB # 한 요청의 최대 허용 크기
+      max-file-size: 2GB # 업로드할 수 있는 개별 파일의 최대 크기
+      max-request-size: 2GB # 한 요청의 최대 허용 크기
 
   mail:
     host: ${EMAIL_HOST}  # Gmail SMTP 서버 (운영 환경에서는 AWS SES 등으로 변경 권장)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,8 +88,9 @@ spring:
             user-name-attribute: id
   servlet:
     multipart:
-      max-file-size: 10MB # 업로드할 수 있는 개별 파일의 최대 크기
-      max-request-size: 10MB # 한 요청의 최대 허용 크기
+      max-file-size: 2GB # 업로드할 수 있는 개별 파일의 최대 크기
+      max-request-size: 2GB # 한 요청의 최대 허용 크기
+
 
   mail:
     host: smtp.gmail.com  # Gmail SMTP 서버 (운영 환경에서는 AWS SES 등으로 변경 권장)

--- a/src/test/java/com/back/domain/file/controller/FileControllerTest.java
+++ b/src/test/java/com/back/domain/file/controller/FileControllerTest.java
@@ -69,7 +69,7 @@ class FileControllerTest {
     }
 
     @Test
-    @DisplayName("파일 업로드 성공")
+    @DisplayName("MultiFile 업로드 - 성공")
     void uploadFile_success() throws Exception {
         // given
         User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));

--- a/src/test/java/com/back/domain/file/service/FileServiceTest.java
+++ b/src/test/java/com/back/domain/file/service/FileServiceTest.java
@@ -11,6 +11,7 @@ import com.back.global.exception.CustomException;
 import com.back.global.exception.ErrorCode;
 import io.findify.s3mock.S3Mock;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -48,6 +49,7 @@ class FileServiceTest {
     }
 
     @Test
+    @DisplayName("MultiPartFile 업로드 테스트 - 성공")
     void uploadFile() {
         // given
         User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
@@ -71,6 +73,7 @@ class FileServiceTest {
     }
 
     @Test
+    @DisplayName("파일의 ID로 업로드된 파일 조회 - 성공")
     void readFile() {
         // given
         User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
@@ -93,6 +96,7 @@ class FileServiceTest {
     }
 
     @Test
+    @DisplayName("기존 파일을 새 MultiPartFile 업데이트 - 성공")
     void updateFile() {
         // given
         User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));
@@ -121,6 +125,7 @@ class FileServiceTest {
     }
 
     @Test
+    @DisplayName("업로드된 파일 삭제 - 성공")
     void deleteFile() {
         // given
         User user = User.createUser("writer", "writer@example.com", passwordEncoder.encode("P@ssw0rd!"));

--- a/src/test/java/com/back/domain/file/service/PresignedUrlServiceTest.java
+++ b/src/test/java/com/back/domain/file/service/PresignedUrlServiceTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class PresignedUrlServiceTest {
+  
+}

--- a/src/test/java/com/back/domain/file/service/PresignedUrlServiceTest.java
+++ b/src/test/java/com/back/domain/file/service/PresignedUrlServiceTest.java
@@ -1,4 +1,53 @@
-import static org.junit.jupiter.api.Assertions.*;
+package com.back.domain.file.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@ExtendWith(MockitoExtension.class)
 class PresignedUrlServiceTest {
-  
+    @Mock
+    private S3Presigner s3Presigner;
+
+    @InjectMocks
+    private PresignedUrlService presignedUrlService;
+
+    // 성능체크 이후 테스트 코드는 이후
+//    @Test
+//    @DisplayName("업로드용 Presigned URL 발급 - 성공")
+//    void generate_presigned_url_success() throws Exception {
+//        // given
+//        String folder = "images";
+//        String filename = "test.jpg";
+//        String expectedKey = folder + "/fake-uuid-" + filename;
+//
+//        // Mocked URL 생성
+//        URL fakeUrl = new URL(
+//                "https://my-test-bucket.s3.ap-northeast-2.amazonaws.com/" + expectedKey
+//        );
+//
+//        PresignedPutObjectRequest fakePresignedRequest = PresignedPutObjectRequest.builder()
+//
+//        // Mock 동작 정의
+//        when(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class)))
+//                .thenReturn(fakePresignedRequest);
+//
+//
+//        // when
+//        PresignedUrlResponseDto dto =
+//                presignedUrlService.generateUploadPresignedUrl(folder, filename);
+//
+//
+//        // then
+//
+//        // 발급된 Presigned URL 형식 검증
+//        assertThat(dto.getUploadUrl()).contains("X-Amz-Algorithm");
+//        assertThat(dto.getUploadUrl()).contains("X-Amz-Signature");
+//
+//        // 예상 S3 오브젝트 파일 형식 검증
+//        assertThat(dto.getObjectUrl()).contains(folder);
+//        assertThat(dto.getObjectUrl()).contains(filename);
+//    }
 }


### PR DESCRIPTION
<!-- PR 제목은 `작업유형: 작업내용` 형식으로 작성 -->
<!-- 예: feat: 로그인 페이지 UI 구현 -->

## 📌 개요

<!-- 어떤 작업을 했는지 간단 요약해주세요 -->
대용량 파일 업로드를 안정적으로 처리하기 위해 Presigned URL 기반 업로드 방식을 도입했습니다. 
또한 파일업로드 관련하여 서버 설정 변경 및 Swagger 문서 보완하였습니다.

## 🔨 작업 내용

<!-- 변경된 주요 내용을 작성해주세요 -->

### 1. 대용량 파일 업로드 테스트 환경 구성
- 서버에서 허용하는 최대 업로드 용량을 10MB → 2GB로 확장

### 2. Presigned URL 방식 업로드 구현
- Presigned PUT URL 발급 API 구현
- Presigned URL 기반 파일 업로드 방식에서 사용되는 Object URL 반환 로직 추가
- S3 Object URL 기반 삭제 API 구현 (S3 key 파싱 포함)

### 3. Swagger 문서 보완
- Multipart 방식 파일 업로드 API 설명
- Presigned URL 방식 업로드 API 설명 추가

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 연결해주세요 (자동 닫기용) -->

Closes #324

## 📝 참고 사항

<!-- 리뷰 시 참고할 만한 내용이 있다면 작성 -->
- 프론트엔드에서 Presigned URL 방식 테스트 시 CORS 설정이 필요할 수 있습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 작성
- [x] 문서/주석 추가 및 최신화
